### PR TITLE
Add dynamic columns for stats info to console

### DIFF
--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -440,16 +440,25 @@ func (c *Console) drawTorrents(g *gocui.Gui) error {
 			fmt.Fprintln(v, "error:", c.errTorrents)
 			return nil
 		}
+
+		_, cy := v.Cursor()
+		_, oy := v.Origin()
+
 		selectedIDrow := -1
+
 		for i, t := range c.torrents {
-			fmt.Fprint(v, getRow(c, t, i))
+			// Get rows only if they are inside the view
+			if i >= oy && i <= oy+halfY-2 {
+				fmt.Fprint(v, getRow(c, t, i))
+			} else {
+				fmt.Fprintln(v, " ")
+			}
 
 			if t.ID == c.selectedID {
 				selectedIDrow = i
 			}
 		}
-		_, cy := v.Cursor()
-		_, oy := v.Origin()
+
 		selectedRow := cy + oy
 		if selectedRow < len(c.torrents) {
 			if c.torrents[selectedRow].ID != c.selectedID && selectedIDrow != -1 {


### PR DESCRIPTION
This is a follow-up to my latest pull request https://github.com/cenkalti/rain/pull/10. This adds support for dynamic columns originally found in stats, to be able to replicate the layout of a traditional torrent client.

Example usage:
`rain client console -columns "# Status ETA Speed Progress Ratio Size Name"`
![rain](https://user-images.githubusercontent.com/639787/74270002-c480ab80-4d0a-11ea-9149-1e7ddc9d3232.png)
