### PR TITLE
Add completion command hook

### DIFF
--- a/internal/storage/filestorage/filestorage.go
+++ b/internal/storage/filestorage/filestorage.go
@@ -33,7 +33,7 @@ func (s *FileStorage) Open(name string, size int64) (f storage.File, exists bool
 	name = filepath.Join(s.dest, name)
 
 	// Create containing dir if not exists.
-	err = os.MkdirAll(filepath.Dir(name), os.ModeDir|0750)
+	err = os.MkdirAll(filepath.Dir(name), os.ModeDir|0o750)
 	if err != nil {
 		return
 	}
@@ -52,7 +52,7 @@ func (s *FileStorage) Open(name string, size int64) (f storage.File, exists bool
 	}()
 
 	// Open OS file.
-	const mode = 0640
+	const mode = 0o640
 	openFlags := os.O_RDWR | os.O_SYNC
 	openFlags = applyNoAtimeFlag(openFlags)
 	of, err = os.OpenFile(name, openFlags, mode)
@@ -77,4 +77,8 @@ func (s *FileStorage) Open(name string, size int64) (f storage.File, exists bool
 		err = of.Truncate(size)
 	}
 	return
+}
+
+func (s *FileStorage) RootDir() string {
+	return s.dest
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -6,6 +6,7 @@ import "io"
 // Storage is an interface for reading/writing torrent files.
 type Storage interface {
 	Open(name string, size int64) (f File, exists bool, err error)
+	RootDir() string
 }
 
 // File interface for reading/writing torrent data.

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -181,6 +181,9 @@ type Config struct {
 	WebseedMaxSources int
 	// Number of maximum simulateous downloads from WebSeed sources.
 	WebseedMaxDownloads int
+
+	// Shell command to execute on torrent completion.
+	OnCompleteCmd []string
 }
 
 // DefaultConfig for Session. Do not pass zero value Config to NewSession. Copy this struct and modify instead.

--- a/torrent/session_cmd.go
+++ b/torrent/session_cmd.go
@@ -1,0 +1,34 @@
+package torrent
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func (s *Session) runOnCompleteCmd(torrent *torrent) {
+	command, err := exec.LookPath(s.config.OnCompleteCmd[0])
+	if err != nil {
+		s.log.Errorf("error resolving completion hook command path: %s", err)
+		return
+	}
+
+	cmd := exec.Command(command)
+	if len(s.config.OnCompleteCmd) > 1 {
+		cmd.Args = append(cmd.Args, s.config.OnCompleteCmd[1:]...)
+	}
+
+	cmd.Env = append(os.Environ(),
+		"RAIN_TORRENT_ADDED="+fmt.Sprint(torrent.addedAt.Unix()),
+		"RAIN_TORRENT_DIR="+torrent.storage.RootDir(),
+		"RAIN_TORRENT_HASH="+hex.EncodeToString(torrent.infoHash[:]),
+		"RAIN_TORRENT_ID="+torrent.id,
+		"RAIN_TORRENT_NAME="+torrent.name)
+
+	s.log.Debugf("executing completion hook for torrent %s: %s", torrent.id, cmd.String())
+
+	if err := cmd.Run(); err != nil {
+		s.log.Errorf("completion hook execution failed: %s", err)
+	}
+}

--- a/torrent/torrent_pieces.go
+++ b/torrent/torrent_pieces.go
@@ -44,5 +44,8 @@ func (t *torrent) checkCompletion() bool {
 	}
 	t.piecePicker = nil
 	t.updateSeedDuration(time.Now())
+	if len(t.session.config.OnCompleteCmd) > 0 {
+		go t.session.runOnCompleteCmd(t)
+	}
 	return true
 }


### PR DESCRIPTION
This change adds an optional torrent completion command hook that
executes a shell command defined in the server configuration
(`oncompletecmd`). The executed command's shell environment is provided
with specific variables relating to the completed torrent:

* `RAIN_TORRENT_ADDED`: the torrent adding date (UNIX timestamp)
* `RAIN_TORRENT_DIR`: the torrent download directory location
* `RAIN_TORRENT_HASH`: the torrent info hash
* `RAIN_TORRENT_ID`: the torrent internal ID in Rain
* `RAIN_TORRENT_NAME`: the torrent name

Implements #20.