### PR TITLE
Fix data race in Tier.go Announce method and torrentsByInfoHash session member variable access

### DIFF
--- a/internal/tracker/tier.go
+++ b/internal/tracker/tier.go
@@ -28,13 +28,13 @@ func NewTier(trackers []Tracker) *Tier {
 // If annouce fails, the next announce will be made to the next Tracker in the tier.
 func (t *Tier) Announce(ctx context.Context, req AnnounceRequest) (*AnnounceResponse, error) {
 	index := atomic.LoadInt32(&t.index)
+	if index == t.trackerCount {
+		index = 0
+	}
 
 	resp, err := t.Trackers[index].Announce(ctx, req)
 	if err != nil {
-		// Re-read index, it could have been modified since the first load
-		index = atomic.LoadInt32(&t.index)
-		index = (index + 1) % t.trackerCount
-		atomic.StoreInt32(&t.index, index)
+		atomic.AddInt32(&t.index, 1)
 	}
 	return resp, err
 }

--- a/internal/tracker/tier.go
+++ b/internal/tracker/tier.go
@@ -10,6 +10,7 @@ import (
 type Tier struct {
 	Trackers []Tracker
 	index    int
+	mutex    *sync.Mutex
 }
 
 var _ Tracker = (*Tier)(nil)
@@ -28,7 +29,7 @@ func NewTier(trackers []Tracker) *Tier {
 func (t *Tier) Announce(ctx context.Context, req AnnounceRequest) (*AnnounceResponse, error) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	
+
 	resp, err := t.Trackers[t.index].Announce(ctx, req)
 	if err != nil {
 		t.index = (t.index + 1) % len(t.Trackers)

--- a/internal/tracker/tier.go
+++ b/internal/tracker/tier.go
@@ -31,6 +31,8 @@ func (t *Tier) Announce(ctx context.Context, req AnnounceRequest) (*AnnounceResp
 
 	resp, err := t.Trackers[index].Announce(ctx, req)
 	if err != nil {
+		// Re-read index, it could have been modified since the first load
+		index = atomic.LoadInt32(&t.index)
 		index = (index + 1) % t.trackerCount
 		atomic.StoreInt32(&t.index, index)
 	}

--- a/internal/tracker/tier.go
+++ b/internal/tracker/tier.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"math/rand"
+	"sync"
 )
 
 // Tier implements the Tracker interface and contains multiple Trackers which tries to announce to the working Tracker.
@@ -18,12 +19,16 @@ func NewTier(trackers []Tracker) *Tier {
 	rand.Shuffle(len(trackers), func(i, j int) { trackers[i], trackers[j] = trackers[j], trackers[i] })
 	return &Tier{
 		Trackers: trackers,
+		mutex: &sync.Mutex{},
 	}
 }
 
 // Announce a torrent to the tracker.
 // If annouce fails, the next announce will be made to the next Tracker in the tier.
 func (t *Tier) Announce(ctx context.Context, req AnnounceRequest) (*AnnounceResponse, error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	
 	resp, err := t.Trackers[t.index].Announce(ctx, req)
 	if err != nil {
 		t.index = (t.index + 1) % len(t.Trackers)

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -60,10 +60,11 @@ type Session struct {
 	mPeerRequests   sync.Mutex
 	dhtPeerRequests map[*torrent]struct{}
 
-	mTorrents          sync.RWMutex
-	torrents           map[string]*Torrent
-	torrentsByInfoHash map[dht.InfoHash][]*Torrent
-	invalidTorrentIDs  []string
+	mTorrents           sync.RWMutex
+	torrents            map[string]*Torrent
+	mTorrentsByInfoHash sync.RWMutex
+	torrentsByInfoHash  map[dht.InfoHash][]*Torrent
+	invalidTorrentIDs   []string
 
 	mPorts         sync.RWMutex
 	availablePorts map[int]struct{}
@@ -348,6 +349,8 @@ func (s *Session) removeTorrentFromClient(id string) (*Torrent, error) {
 
 	// Delete from the list of torrents with same info hash
 	ih := dht.InfoHash(t.torrent.InfoHash())
+	s.mTorrentsByInfoHash.Lock()
+	defer s.mTorrentsByInfoHash.Unlock()
 	a := s.torrentsByInfoHash[ih]
 	for i, it := range a {
 		if it == t {

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -283,6 +283,8 @@ func (s *Session) insertTorrent(t *torrent) *Torrent {
 	defer s.mTorrents.Unlock()
 	s.torrents[t.id] = t2
 	ih := dht.InfoHash(t.InfoHash())
+	s.mTorrentsByInfoHash.Lock()
 	s.torrentsByInfoHash[ih] = append(s.torrentsByInfoHash[ih], t2)
+	s.mTorrentsByInfoHash.Unlock()
 	return t2
 }

--- a/torrent/session_dht.go
+++ b/torrent/session_dht.go
@@ -14,7 +14,9 @@ func (s *Session) processDHTResults() {
 			s.handleDHTtick()
 		case res := <-s.dht.PeersRequestResults:
 			for ih, peers := range res {
+				s.mTorrentsByInfoHash.RLock()
 				torrents, ok := s.torrentsByInfoHash[ih]
+				s.mTorrentsByInfoHash.RUnlock()
 				if !ok {
 					continue
 				}


### PR DESCRIPTION
Fix #25 by adding a mutex. There is probably a more lightweight approach (atomic) but that does fix the data race in my unittest.