### PR TITLE
Allow the configuration of filesystem permissions.

### DIFF
--- a/torrent/config.go
+++ b/torrent/config.go
@@ -1,6 +1,7 @@
 package torrent
 
 import (
+	"io/fs"
 	"time"
 
 	"github.com/cenkalti/rain/internal/metainfo"
@@ -75,6 +76,8 @@ type Config struct {
 	HealthCheckInterval time.Duration
 	// If torrent loop is stuck for more than this duration. Program crashes with stacktrace.
 	HealthCheckTimeout time.Duration
+	// The unix permission of created files, execute bit is removed for files
+	FilePermissions fs.FileMode
 
 	// Enable RPC server
 	RPCEnabled bool
@@ -220,6 +223,7 @@ var DefaultConfig = Config{
 	ResumeOnStartup:                        true,
 	HealthCheckInterval:                    10 * time.Second,
 	HealthCheckTimeout:                     60 * time.Second,
+	FilePermissions:                        0o750,
 
 	// RPC Server
 	RPCEnabled:         true,

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -95,12 +95,12 @@ func NewSession(cfg Config) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = os.MkdirAll(filepath.Dir(cfg.Database), 0750)
+	err = os.MkdirAll(filepath.Dir(cfg.Database), os.ModeDir|cfg.FilePermissions)
 	if err != nil {
 		return nil, err
 	}
 	l := logger.New("session")
-	db, err := bbolt.Open(cfg.Database, 0640, &bbolt.Options{Timeout: time.Second})
+	db, err := bbolt.Open(cfg.Database, cfg.FilePermissions&^0111, &bbolt.Options{Timeout: time.Second})
 	if err == bbolt.ErrTimeout {
 		return nil, errors.New("resume database is locked by another process")
 	} else if err != nil {

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -266,7 +266,7 @@ func (s *Session) add(opt *AddTorrentOptions) (id string, port int, sto *filesto
 		}
 		id = base64.RawURLEncoding.EncodeToString(u1[:])
 	}
-	sto, err = filestorage.New(s.getDataDir(id))
+	sto, err = filestorage.New(s.getDataDir(id), s.config.FilePermissions)
 	if err != nil {
 		return
 	}

--- a/torrent/session_load.go
+++ b/torrent/session_load.go
@@ -73,7 +73,7 @@ func (s *Session) loadExistingTorrent(id string) (tt *Torrent, hasStarted bool, 
 			bf = bf3
 		}
 	}
-	sto, err := filestorage.New(s.getDataDir(id))
+	sto, err := filestorage.New(s.getDataDir(id), s.config.FilePermissions)
 	if err != nil {
 		return
 	}

--- a/torrent/torrent_test.go
+++ b/torrent/torrent_test.go
@@ -74,7 +74,7 @@ func seeder(t *testing.T, clearTrackers bool) (addr string, c func()) {
 	}
 	src := filepath.Join(torrentDataDir, torrentName)
 	dst := filepath.Join(s.config.DataDir, tor.ID(), torrentName)
-	err = os.Mkdir(filepath.Join(s.config.DataDir, tor.ID()), os.ModeDir|0750)
+	err = os.Mkdir(filepath.Join(s.config.DataDir, tor.ID()), os.ModeDir|s.config.FilePermissions)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hello! I've been setting up _rain_ in k8s and serving downloaded files locally using a samba server but I ran into the issue that _rain_ creates files and directories with file permissions 0750 and 0640 (which the samba doesn't export). The easiest solution for me was to have _rain_ create files as 0755&0644.

This PR adds the config option `FilePermissions` allowing the users to choose which permissions files and directories should be created with. For directories it takes the config value and for files it'll strip off the execution bit of the value (that's a bad idea in any case). e.g if you set it to 0755 files, will be created with 0644.

Hope this can be of help. 👍🏻 