### PR TITLE
fix torrent.NotifyComplete not notified after verification done

### DIFF
--- a/torrent/torrent_verification.go
+++ b/torrent/torrent_verification.go
@@ -54,7 +54,9 @@ func (t *torrent) handleVerificationDone(ve *verifier.Verifier) {
 	// We may detect missing pieces after verification. Then, status must be set from Seeding to Downloading.
 	if !t.bitfield.All() {
 		t.completed = false
-		t.completeC = make(chan struct{})
+		if t.completeC == nil {
+			t.completeC = make(chan struct{})
+		}
 	}
 
 	if t.doVerify {


### PR DESCRIPTION
When start a torrent, t.completeC will be a value, and t.NotifyComplete return this channel value.

Then after t.handleVerificationDone, t.completeC may recreated with new value, but we still listen on old channel value.

So we will miss completeC close event.
