### PR TITLE
Add RootDirectory and Files functions to Torrent

### DIFF
--- a/torrent/session_torrent.go
+++ b/torrent/session_torrent.go
@@ -42,6 +42,18 @@ func (t *Torrent) Name() string {
 	return t.torrent.Name()
 }
 
+// RootDirectory of the torrent.
+// The directory that contains the files in the torrent.
+func (t *Torrent) RootDirectory() string {
+	return t.torrent.RootDirectory()
+}
+
+// The files in the torrent.
+// The names of the files are relative to the root directory.
+func (t *Torrent) Files() ([]string, error) {
+	return t.torrent.Files()
+}
+
 // InfoHash returns the hash of the info dictionary of torrent file.
 // Two different torrents may have the same info hash.
 func (t *Torrent) InfoHash() InfoHash {

--- a/torrent/session_torrent.go
+++ b/torrent/session_torrent.go
@@ -49,9 +49,9 @@ func (t *Torrent) RootDirectory() string {
 }
 
 // The files in the torrent.
-// The names of the files are relative to the root directory.
-func (t *Torrent) Files() ([]string, error) {
-	return t.torrent.Files()
+// The paths of the files are relative to the root directory.
+func (t *Torrent) FilePaths() ([]string, error) {
+	return t.torrent.FilePaths()
 }
 
 // InfoHash returns the hash of the info dictionary of torrent file.

--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -418,16 +418,18 @@ func (t *torrent) RootDirectory() string {
 	return t.storage.RootDir()
 }
 
-func (t *torrent) Files() ([]string, error) {
+func (t *torrent) FilePaths() ([]string, error) {
 	if t.info == nil {
 		return nil, errors.New("torrent metadata not ready")
 	}
 
-	fileNames := make([]string, len(t.info.Files))
-	for i, f := range t.info.Files {
-		fileNames[i] = f.Path
+	var filePaths []string
+	for _, f := range t.info.Files {
+		if !f.Padding {
+			filePaths = append(filePaths, f.Path)
+		}
 	}
-	return fileNames, nil
+	return filePaths, nil
 }
 
 func (t *torrent) announceDHT() {

--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cenkalti/rain/internal/handshaker/incominghandshaker"
 	"github.com/cenkalti/rain/internal/handshaker/outgoinghandshaker"
 	"github.com/cenkalti/rain/internal/infodownloader"
-	"github.com/cenkalti/rain/internal/urldownloader"
 	"github.com/cenkalti/rain/internal/logger"
 	"github.com/cenkalti/rain/internal/metainfo"
 	"github.com/cenkalti/rain/internal/mse"
@@ -34,6 +33,7 @@ import (
 	"github.com/cenkalti/rain/internal/suspendchan"
 	"github.com/cenkalti/rain/internal/tracker"
 	"github.com/cenkalti/rain/internal/unchoker"
+	"github.com/cenkalti/rain/internal/urldownloader"
 	"github.com/cenkalti/rain/internal/verifier"
 	"github.com/cenkalti/rain/internal/webseedsource"
 	"github.com/rcrowley/go-metrics"
@@ -412,6 +412,22 @@ func (t *torrent) InfoHash() []byte {
 	b := make([]byte, 20)
 	copy(b, t.infoHash[:])
 	return b
+}
+
+func (t *torrent) RootDirectory() string {
+	return t.storage.RootDir()
+}
+
+func (t *torrent) Files() ([]string, error) {
+	if t.info == nil {
+		return nil, errors.New("torrent metadata not ready")
+	}
+
+	fileNames := make([]string, len(t.info.Files))
+	for i, f := range t.info.Files {
+		fileNames[i] = f.Path
+	}
+	return fileNames, nil
 }
 
 func (t *torrent) announceDHT() {

--- a/torrent/torrent_test.go
+++ b/torrent/torrent_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/chihaya/chihaya/storage"
 	_ "github.com/chihaya/chihaya/storage/memory"
 	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -149,6 +151,42 @@ func TestDownloadTorrent(t *testing.T) {
 	assertCompleted(t, tor)
 }
 
+func TestTorrentRootDirectory(t *testing.T) {
+	defer leaktest.Check(t)()
+	addr, cl := seeder(t, true)
+	defer cl()
+	s, closeSession := newTestSession(t)
+	defer closeSession()
+
+	tor, err := s.AddURI(torrentMagnetLink+"&x.pe="+addr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, path.Join(s.config.DataDir, tor.ID()), tor.RootDirectory())
+	assertCompleted(t, tor)
+}
+
+func TestTorrentFiles(t *testing.T) {
+	defer leaktest.Check(t)()
+	addr, cl := seeder(t, true)
+	defer cl()
+	s, closeSession := newTestSession(t)
+	defer closeSession()
+
+	tor, err := s.AddURI(torrentMagnetLink+"&x.pe="+addr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tor.Files()
+	assert.EqualError(t, err, "torrent metadata not ready")
+	waitForMetadata(t, tor)
+	files, err := tor.Files()
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(files))
+	assert.Equal(t, "sample_torrent/data/file1.bin", files[0])
+	assertCompleted(t, tor)
+}
+
 func startHTTPTracker(t *testing.T) (stop func()) {
 	responseConfig := middleware.ResponseConfig{
 		AnnounceInterval: time.Minute,
@@ -242,5 +280,16 @@ func assertCompleted(t *testing.T, tor *Torrent) {
 	err := cmd.Run()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func waitForMetadata(t *testing.T, tor *Torrent) {
+	t2 := tor.torrent
+	select {
+	case <-t2.NotifyMetadata():
+	case err := <-t2.NotifyError():
+		t.Fatal(err)
+	case <-time.After(timeout):
+		t.Fatal("metadata did not finish downloading")
 	}
 }

--- a/torrent/torrent_test.go
+++ b/torrent/torrent_test.go
@@ -177,10 +177,10 @@ func TestTorrentFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = tor.Files()
+	_, err = tor.FilePaths()
 	assert.EqualError(t, err, "torrent metadata not ready")
 	waitForMetadata(t, tor)
-	files, err := tor.Files()
+	files, err := tor.FilePaths()
 	assert.NoError(t, err)
 	assert.Equal(t, 6, len(files))
 	assert.Equal(t, "sample_torrent/data/file1.bin", files[0])


### PR DESCRIPTION
I want access to the downloaded files after the torrent finishes downloading. This PR adds a public function to `Torrent` to expose that.