### PR TITLE
Add a NotifyClose() API.

### DIFF
--- a/torrent/torrent_commands.go
+++ b/torrent/torrent_commands.go
@@ -51,6 +51,10 @@ func (t *torrent) Close() {
 	<-t.doneC
 }
 
+func (t *torrent) NotifyClose() <-chan struct{} {
+	return t.closeC
+}
+
 func (t *torrent) NotifyComplete() <-chan struct{} {
 	return t.completeC
 }


### PR DESCRIPTION
To allow clients to watch the full lifecycle of a torrent, knowing if the torrent has been closed is important. Expose the closeC channel to callers to they can watch for it being closed as an indication that the torrent is being completely dropped.