### PR TITLE
Fix a brown paper bag level typo: s/NotifyCose/NotifyClose/.

### DIFF
--- a/torrent/session_torrent.go
+++ b/torrent/session_torrent.go
@@ -104,10 +104,10 @@ func (t *Torrent) Port() int {
 	return t.torrent.port
 }
 
-// NotifyCose returns a channel for notifying removal/closure.  The
+// NotifyClose returns a channel for notifying removal/closure.  The
 // channel is closed once RemoveTorrent() is called, dropping it from
 // the session.
-func (t *Torrent) NotifyCose() <-chan struct{} {
+func (t *Torrent) NotifyClose() <-chan struct{} {
 	return t.torrent.NotifyClose()
 }
 


### PR DESCRIPTION
Apologies for this. Autocomplete in my editor let me type it wrong once and the fill it in elsewhere, including where I used it locally when I was validating it gave me what I wanted. :(