### PR TITLE
Add a FileStats() interface that is backed by a per-file stats object

### DIFF
--- a/internal/resumer/boltdbresumer/spec.go
+++ b/internal/resumer/boltdbresumer/spec.go
@@ -8,41 +8,43 @@ import (
 
 // Spec contains fields for resuming an existing torrent.
 type Spec struct {
-	InfoHash          []byte
-	Port              int
-	Name              string
-	Trackers          [][]string
-	URLList           []string
-	FixedPeers        []string
-	Info              []byte
-	Bitfield          []byte
-	AddedAt           time.Time
-	BytesDownloaded   int64
-	BytesUploaded     int64
-	BytesWasted       int64
-	SeededFor         time.Duration
-	Started           bool
-	StopAfterDownload bool
-	StopAfterMetadata bool
-	CompleteCmdRun    bool
-	Version           int
+	InfoHash               []byte
+	Port                   int
+	Name                   string
+	Trackers               [][]string
+	URLList                []string
+	FixedPeers             []string
+	Info                   []byte
+	Bitfield               []byte
+	AddedAt                time.Time
+	BytesDownloaded        int64
+	BytesUploaded          int64
+	BytesWasted            int64
+	PerFileBytesDownloaded []int64 // Indexed by metadata Files index id
+	SeededFor              time.Duration
+	Started                bool
+	StopAfterDownload      bool
+	StopAfterMetadata      bool
+	CompleteCmdRun         bool
+	Version                int
 }
 
 type jsonSpec struct {
-	Port              int
-	Name              string
-	Trackers          [][]string
-	URLList           []string
-	FixedPeers        []string
-	AddedAt           time.Time
-	BytesDownloaded   int64
-	BytesUploaded     int64
-	BytesWasted       int64
-	Started           bool
-	StopAfterDownload bool
-	StopAfterMetadata bool
-	CompleteCmdRun    bool
-	Version           int
+	Port                   int
+	Name                   string
+	Trackers               [][]string
+	URLList                []string
+	FixedPeers             []string
+	AddedAt                time.Time
+	BytesDownloaded        int64
+	BytesUploaded          int64
+	BytesWasted            int64
+	PerFileBytesDownloaded []int64 // Indexed by metadata Files index id
+	Started                bool
+	StopAfterDownload      bool
+	StopAfterMetadata      bool
+	CompleteCmdRun         bool
+	Version                int
 
 	// JSON unsafe types
 	InfoHash  string
@@ -54,20 +56,21 @@ type jsonSpec struct {
 // MarshalJSON converts the Spec to a JSON string.
 func (s Spec) MarshalJSON() ([]byte, error) {
 	j := jsonSpec{
-		Port:              s.Port,
-		Name:              s.Name,
-		Trackers:          s.Trackers,
-		URLList:           s.URLList,
-		FixedPeers:        s.FixedPeers,
-		AddedAt:           s.AddedAt,
-		BytesDownloaded:   s.BytesDownloaded,
-		BytesUploaded:     s.BytesUploaded,
-		BytesWasted:       s.BytesWasted,
-		Started:           s.Started,
-		StopAfterDownload: s.StopAfterDownload,
-		StopAfterMetadata: s.StopAfterMetadata,
-		CompleteCmdRun:    s.CompleteCmdRun,
-		Version:           s.Version,
+		Port:                   s.Port,
+		Name:                   s.Name,
+		Trackers:               s.Trackers,
+		URLList:                s.URLList,
+		FixedPeers:             s.FixedPeers,
+		AddedAt:                s.AddedAt,
+		BytesDownloaded:        s.BytesDownloaded,
+		BytesUploaded:          s.BytesUploaded,
+		BytesWasted:            s.BytesWasted,
+		PerFileBytesDownloaded: s.PerFileBytesDownloaded,
+		Started:                s.Started,
+		StopAfterDownload:      s.StopAfterDownload,
+		StopAfterMetadata:      s.StopAfterMetadata,
+		CompleteCmdRun:         s.CompleteCmdRun,
+		Version:                s.Version,
 
 		InfoHash:  base64.StdEncoding.EncodeToString(s.InfoHash),
 		Info:      base64.StdEncoding.EncodeToString(s.Info),
@@ -106,6 +109,7 @@ func (s *Spec) UnmarshalJSON(b []byte) error {
 	s.BytesDownloaded = j.BytesDownloaded
 	s.BytesUploaded = j.BytesUploaded
 	s.BytesWasted = j.BytesWasted
+	s.PerFileBytesDownloaded = j.PerFileBytesDownloaded
 	s.Started = j.Started
 	s.StopAfterDownload = j.StopAfterDownload
 	s.StopAfterMetadata = j.StopAfterMetadata

--- a/internal/resumer/boltdbresumer/spec_test.go
+++ b/internal/resumer/boltdbresumer/spec_test.go
@@ -2,13 +2,15 @@ package boltdbresumer
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
 func TestMarshalUnmarshalSpec(t *testing.T) {
 	s := Spec{
-		Info: []byte{1, 2, 3},
-		Name: "foo",
+		Info:                   []byte{1, 2, 3},
+		Name:                   "foo",
+		PerFileBytesDownloaded: []int64{10, 20, 30, 100},
 	}
 	b, err := s.MarshalJSON()
 	if err != nil {
@@ -23,6 +25,9 @@ func TestMarshalUnmarshalSpec(t *testing.T) {
 		t.FailNow()
 	}
 	if s.Name != s2.Name {
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(s.PerFileBytesDownloaded, s2.PerFileBytesDownloaded) {
 		t.FailNow()
 	}
 }

--- a/internal/resumer/resumer.go
+++ b/internal/resumer/resumer.go
@@ -3,8 +3,9 @@ package resumer
 
 // Stats of a torrent.
 type Stats struct {
-	BytesDownloaded int64
-	BytesUploaded   int64
-	BytesWasted     int64
-	SeededFor       int64 // time.Duration
+	BytesDownloaded        int64
+	BytesUploaded          int64
+	BytesWasted            int64
+	SeededFor              int64   // time.Duration
+	PerFileBytesDownloaded []int64 // Indexed by metadata.Info Files index id
 }

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -87,7 +87,7 @@ func (s *Session) addTorrentStopped(r io.Reader, opt *AddTorrentOptions) (*Torre
 		nil, // fixedPeers
 		&mi.Info,
 		nil, // bitfield
-		resumer.Stats{},
+		resumer.Stats{PerFileBytesDownloaded: make([]int64, len(mi.Info.Files))},
 		webseedsource.NewList(mi.URLList),
 		opt.StopAfterDownload,
 		opt.StopAfterMetadata,

--- a/torrent/session_load.go
+++ b/torrent/session_load.go
@@ -86,6 +86,11 @@ func (s *Session) loadExistingTorrent(id string) (tt *Torrent, hasStarted bool, 
 			bf = bf3
 		}
 	}
+	// Cover transition from when this data wasn't tracked
+	if len(spec.PerFileBytesDownloaded) == 0 {
+		spec.PerFileBytesDownloaded = make([]int64, len(info.Files))
+	}
+
 	sto, err := filestorage.New(s.getDataDir(id), s.config.FilePermissions)
 	if err != nil {
 		return
@@ -103,10 +108,11 @@ func (s *Session) loadExistingTorrent(id string) (tt *Torrent, hasStarted bool, 
 		info,
 		bf,
 		resumer.Stats{
-			BytesDownloaded: spec.BytesDownloaded,
-			BytesUploaded:   spec.BytesUploaded,
-			BytesWasted:     spec.BytesWasted,
-			SeededFor:       int64(spec.SeededFor),
+			BytesDownloaded:        spec.BytesDownloaded,
+			BytesUploaded:          spec.BytesUploaded,
+			BytesWasted:            spec.BytesWasted,
+			SeededFor:              int64(spec.SeededFor),
+			PerFileBytesDownloaded: spec.PerFileBytesDownloaded,
 		},
 		webseedsource.NewList(spec.URLList),
 		spec.StopAfterDownload,

--- a/torrent/session_torrent.go
+++ b/torrent/session_torrent.go
@@ -48,6 +48,10 @@ func (t *Torrent) RootDirectory() string {
 	return t.torrent.RootDirectory()
 }
 
+func (t *Torrent) FileStats() ([]fileStat, error) {
+	return t.torrent.FileStats()
+}
+
 // The files in the torrent.
 // The paths of the files are relative to the root directory.
 func (t *Torrent) FilePaths() ([]string, error) {

--- a/torrent/torrent_write.go
+++ b/torrent/torrent_write.go
@@ -77,6 +77,12 @@ func (t *torrent) handlePieceWriteDone(pw *piecewriter.PieceWriter) {
 		pe.SendMessage(msg)
 	}
 
+	t.mPerFile.Lock()
+	for fp, b := range pw.PerFileBytes {
+		t.perFileBytesDownloaded[fp].Inc(b)
+	}
+	t.mPerFile.Unlock()
+
 	completed := t.checkCompletion()
 	if completed {
 		t.log.Info("download completed")


### PR DESCRIPTION
For now, this only tracks per-file bytes completed. It supports roundtripping the data through the botldb persistence layer. This is in service of addressing issue #93.

I'm torn on wrapping the map in a mutex. The underlying counters should take care of themselves in the face of concurrent access and we _should_ only add keys at safe times where concurrency isn't in play, but I've wrapped it anyway as a safer practice.

We haven't yet agreed on the actual FileStats() interface, so this is just a working example of what I'm thinking. Happy to tweak.