### PR TITLE
Add a Files method to the Torrent object.

### DIFF
--- a/torrent/session_torrent.go
+++ b/torrent/session_torrent.go
@@ -54,6 +54,12 @@ func (t *Torrent) FilePaths() ([]string, error) {
 	return t.torrent.FilePaths()
 }
 
+// The files in the torrent with completion info. An error is returned
+// when metainfo isn't ready.
+func (t *Torrent) Files() ([]File, error) {
+	return t.torrent.Files()
+}
+
 // InfoHash returns the hash of the info dictionary of torrent file.
 // Two different torrents may have the same info hash.
 func (t *Torrent) InfoHash() InfoHash {


### PR DESCRIPTION
This method returns a slice of File objects, newly defined for this purpose. Each File has a Path and Stats method which allow querying for the file path and per-file size and download completion in bytes. This method is only usable when metainfo is available (torrent in one of the running states) as it relies on piece data to build up the notion of completeness. The piece done state, which should mirror the bitfield completion status is how we determine whether or not to count bytes as completed for the file sections in that particular piece. Padding files are ignored.