### PR TITLE
show number of pieces in error message when there are too many

### DIFF
--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -55,7 +55,7 @@ func (s *Session) parseMetaInfo(r io.Reader) (*metainfo.MetaInfo, error) {
 		return nil, err
 	}
 	if mi.Info.NumPieces > s.config.MaxPieces {
-		return nil, fmt.Errorf("too many pieces:(%d)", mi.Info.NumPieces)
+		return nil, fmt.Errorf("too many pieces: %d", mi.Info.NumPieces)
 	}
 	return mi, nil
 }

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -55,7 +55,7 @@ func (s *Session) parseMetaInfo(r io.Reader) (*metainfo.MetaInfo, error) {
 		return nil, err
 	}
 	if mi.Info.NumPieces > s.config.MaxPieces {
-		return nil, errTooManyPieces
+		return nil, fmt.Errorf("too many pieces:(%d)", mi.Info.NumPieces)
 	}
 	return mi, nil
 }

--- a/torrent/session_load.go
+++ b/torrent/session_load.go
@@ -1,7 +1,6 @@
 package torrent
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cenkalti/rain/internal/bitfield"
@@ -12,8 +11,6 @@ import (
 	"github.com/cenkalti/rain/internal/webseedsource"
 	"go.etcd.io/bbolt"
 )
-
-var errTooManyPieces = errors.New("too many pieces")
 
 func (s *Session) loadExistingTorrents(ids []string) {
 	var loaded int
@@ -57,7 +54,7 @@ func (s *Session) parseInfo(b []byte, version int) (*metainfo.Info, error) {
 		return nil, err
 	}
 	if i.NumPieces > s.config.MaxPieces {
-		return nil, errTooManyPieces
+		return nil, fmt.Errorf("too many pieces: %d", i.NumPieces)
 	}
 	return i, nil
 }


### PR DESCRIPTION
Show the number of pieces in a torrent that has too many. This makes it easier to adjust your config if needed for special cases since you can see the actual number of pieces needed. 