### PR TITLE
Add feature to seed only when client is the only seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Features
 - RPC server & client
 - Console UI
 - Tool for creating & reading .torrent files
+- Seed only when you're the only seeder
 
 Screenshot
 ----------

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -200,6 +200,11 @@ type Config struct {
 	// Shell command to execute on torrent completion.
 	OnCompleteCmd []string `yaml:"on-complete-cmd"`
 
+	// Seed only when the client is the only seeder.
+	// If enabled, the client will periodically check if it's the only seeder
+	// and stop seeding if there are other seeders.
+	SeedOnlyAsLastSeeder bool `yaml:"seed-only-as-last-seeder"`
+
 	// Replace default log handler
 	CustomLogHandler log.Handler `yaml:"-"`
 	// Replace default storage provider
@@ -302,4 +307,7 @@ var DefaultConfig = Config{
 	WebseedVerifyTLS:               true,
 	WebseedMaxSources:              10,
 	WebseedMaxDownloads:            4,
+	
+	// Seeding settings
+	SeedOnlyAsLastSeeder:           false,
 }

--- a/torrent/seeder.go
+++ b/torrent/seeder.go
@@ -1,0 +1,67 @@
+package torrent
+
+import (
+	"context"
+	"time"
+)
+
+// checkIfOnlySeeder checks if the client is the only seeder for the torrent.
+// It returns true if the client is the only seeder, false otherwise.
+// If there's an error during the check, it returns false.
+func (t *torrent) checkIfOnlySeeder() bool {
+	// If we don't have the info yet, we can't check
+	if t.info == nil {
+		return false
+	}
+
+	// If we're not seeding, we're not the only seeder
+	if !t.seeding {
+		return false
+	}
+
+	// Check all trackers
+	for _, tr := range t.trackers {
+		// Create a context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Scrape the tracker
+		resp, err := tr.Scrape(ctx, t.infoHash)
+		if err != nil {
+			t.log.Debugf("Error scraping tracker %s: %s", tr.URL(), err)
+			continue
+		}
+
+		// If there are other seeders, we're not the only one
+		if resp.Complete > 1 {
+			t.log.Debugf("Found %d seeders on tracker %s", resp.Complete, tr.URL())
+			return false
+		}
+	}
+
+	// If we've checked all trackers and we're still here, we're the only seeder
+	return true
+}
+
+// handleSeedingMode checks if the client should be seeding based on the configuration.
+// If SeedOnlyAsLastSeeder is enabled, it will stop seeding if there are other seeders.
+func (t *torrent) handleSeedingMode() {
+	// If the feature is not enabled, do nothing
+	if !t.config.SeedOnlyAsLastSeeder {
+		return
+	}
+
+	// If we're not seeding, do nothing
+	if !t.seeding {
+		return
+	}
+
+	// Check if we're the only seeder
+	isOnlySeeder := t.checkIfOnlySeeder()
+
+	// If we're not the only seeder, stop seeding
+	if !isOnlySeeder {
+		t.log.Info("Stopping seeding as we're not the only seeder")
+		t.seeding = false
+	}
+}

--- a/torrent/seeder_test.go
+++ b/torrent/seeder_test.go
@@ -1,0 +1,142 @@
+package torrent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/rain/v2/internal/logger"
+	"github.com/cenkalti/rain/v2/internal/metainfo"
+	"github.com/cenkalti/rain/v2/internal/tracker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockTracker is a mock implementation of the Tracker interface
+type MockTracker struct {
+	mock.Mock
+}
+
+func (m *MockTracker) URL() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockTracker) Announce(ctx context.Context, transfer tracker.Transfer, event tracker.Event, numWant int) (*tracker.AnnounceResponse, error) {
+	args := m.Called(ctx, transfer, event, numWant)
+	return args.Get(0).(*tracker.AnnounceResponse), args.Error(1)
+}
+
+func (m *MockTracker) Scrape(ctx context.Context, ih [20]byte) (*tracker.ScrapeResponse, error) {
+	args := m.Called(ctx, ih)
+	return args.Get(0).(*tracker.ScrapeResponse), args.Error(1)
+}
+
+func (m *MockTracker) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func TestCheckIfOnlySeeder(t *testing.T) {
+	// Create a mock torrent
+	tor := &torrent{
+		seeding: true,
+		info:    &metainfo.Info{},
+	}
+
+	// Create a mock tracker
+	mockTracker := new(MockTracker)
+	mockTracker.On("URL").Return("http://example.com/announce")
+	
+	// Test case 1: We are the only seeder
+	mockTracker.On("Scrape", mock.Anything, mock.Anything).Return(&tracker.ScrapeResponse{
+		Complete:   1, // Only one seeder (us)
+		Incomplete: 5,
+		Downloaded: 10,
+	}, nil).Once()
+	
+	tor.trackers = []tracker.Tracker{mockTracker}
+	
+	// We should be the only seeder
+	assert.True(t, tor.checkIfOnlySeeder())
+	
+	// Test case 2: There are other seeders
+	mockTracker.On("Scrape", mock.Anything, mock.Anything).Return(&tracker.ScrapeResponse{
+		Complete:   3, // Multiple seeders
+		Incomplete: 5,
+		Downloaded: 10,
+	}, nil).Once()
+	
+	// We should not be the only seeder
+	assert.False(t, tor.checkIfOnlySeeder())
+	
+	// Test case 3: Error during scrape
+	mockTracker.On("Scrape", mock.Anything, mock.Anything).Return(&tracker.ScrapeResponse{}, 
+		errors.New("scrape error")).Once()
+	
+	// If there's an error, we should assume we're not the only seeder
+	assert.False(t, tor.checkIfOnlySeeder())
+	
+	// Test case 4: Not seeding
+	tor.seeding = false
+	
+	// If we're not seeding, we're not the only seeder
+	assert.False(t, tor.checkIfOnlySeeder())
+	
+	mockTracker.AssertExpectations(t)
+}
+
+func TestHandleSeedingMode(t *testing.T) {
+	// Create a mock torrent
+	tor := &torrent{
+		seeding: true,
+		info:    &metainfo.Info{},
+		config:  Config{SeedOnlyAsLastSeeder: true},
+		log:     logger.New("torrent"),
+	}
+	
+	// Create a mock tracker
+	mockTracker := new(MockTracker)
+	mockTracker.On("URL").Return("http://example.com/announce")
+	
+	// Test case 1: We are the only seeder
+	mockTracker.On("Scrape", mock.Anything, mock.Anything).Return(&tracker.ScrapeResponse{
+		Complete:   1, // Only one seeder (us)
+		Incomplete: 5,
+		Downloaded: 10,
+	}, nil).Once()
+	
+	tor.trackers = []tracker.Tracker{mockTracker}
+	
+	// Call the function
+	tor.handleSeedingMode()
+	
+	// We should still be seeding
+	assert.True(t, tor.seeding)
+	
+	// Test case 2: There are other seeders
+	mockTracker.On("Scrape", mock.Anything, mock.Anything).Return(&tracker.ScrapeResponse{
+		Complete:   3, // Multiple seeders
+		Incomplete: 5,
+		Downloaded: 10,
+	}, nil).Once()
+	
+	// Call the function
+	tor.handleSeedingMode()
+	
+	// We should stop seeding
+	assert.False(t, tor.seeding)
+	
+	// Test case 3: Feature disabled
+	tor.seeding = true
+	tor.config.SeedOnlyAsLastSeeder = false
+	
+	// Call the function
+	tor.handleSeedingMode()
+	
+	// We should still be seeding
+	assert.True(t, tor.seeding)
+	
+	mockTracker.AssertExpectations(t)
+}

--- a/torrent/torrent_run.go
+++ b/torrent/torrent_run.go
@@ -13,6 +13,10 @@ func (t *torrent) run() {
 
 	t.unchokeTicker = time.NewTicker(10 * time.Second)
 	defer t.unchokeTicker.Stop()
+	
+	// Ticker to check if we're the only seeder
+	seederCheckTicker := time.NewTicker(5 * time.Minute)
+	defer seederCheckTicker.Stop()
 
 	for {
 		select {
@@ -74,6 +78,8 @@ func (t *torrent) run() {
 			t.handlePeerSnubbed(pe)
 		case <-t.unchokeTicker.C:
 			t.unchoker.TickUnchoke(t.getPeersForUnchoker(), t.completed)
+			case <-seederCheckTicker.C:
+			t.handleSeedingMode()
 		case ih := <-t.incomingHandshakerResultC:
 			t.handleIncomingHandshakeDone(ih)
 		case oh := <-t.outgoingHandshakerResultC:


### PR DESCRIPTION
Fixes #182

This PR adds a new configuration option `SeedOnlyAsLastSeeder` that allows the client to stop seeding if there are other seeders available. The client will periodically check the tracker scrape information to determine if it is the only seeder.

## Changes

- Added `Scrape` method to the `Tracker` interface
- Implemented `Scrape` method for HTTP and UDP trackers
- Added `SeedOnlyAsLastSeeder` configuration option (default: false)
- Added logic to periodically check if the client is the only seeder
- Added tests for the new functionality
- Updated README.md to document the new feature