### PR TITLE
Add custom dial function support and configurable TLS/UDP tracker settings

### DIFF
--- a/internal/announcer/periodic.go
+++ b/internal/announcer/periodic.go
@@ -58,6 +58,7 @@ type PeriodicalAnnouncer struct {
 	responseC     chan *tracker.AnnounceResponse
 	errC          chan error
 	closeC        chan struct{}
+	closeOnce     sync.Once
 	doneC         chan struct{}
 
 	needMorePeers  bool
@@ -93,7 +94,7 @@ func NewPeriodicalAnnouncer(trk tracker.Tracker, numWant int, minInterval time.D
 
 // Close the announcer.
 func (a *PeriodicalAnnouncer) Close() {
-	close(a.closeC)
+	a.closeOnce.Do(func() { close(a.closeC) })
 	<-a.doneC
 }
 
@@ -103,6 +104,13 @@ type statsRequest struct {
 
 // Stats about the tracker and the announce operation.
 func (a *PeriodicalAnnouncer) Stats() Stats {
+	// If Run has exited, return the last known state directly
+	// since the event loop is no longer processing statsCommandC.
+	select {
+	case <-a.doneC:
+		return a.stats()
+	default:
+	}
 	var stats Stats
 	req := statsRequest{Response: make(chan Stats, 1)}
 	select {
@@ -196,6 +204,7 @@ func (a *PeriodicalAnnouncer) Run() {
 			}
 			if errors.Is(err, tracker.ErrUDPDisabled) {
 				a.status = Stopped
+				a.closeOnce.Do(func() { close(a.closeC) })
 				cancel()
 				return
 			}

--- a/internal/announcer/periodic.go
+++ b/internal/announcer/periodic.go
@@ -2,6 +2,7 @@ package announcer
 
 import (
 	"context"
+	"errors"
 	"math"
 	"net"
 	"net/url"
@@ -30,6 +31,8 @@ const (
 	Working
 	// NotWorking as expected.
 	NotWorking
+	// Stopped permanently, no further announces will be made.
+	Stopped
 )
 
 // PeriodicalAnnouncer announces the Torrent to the Tracker periodically.
@@ -191,6 +194,11 @@ func (a *PeriodicalAnnouncer) Run() {
 			} else {
 				a.log.Debugln("announce error:", a.lastError.Err.Error())
 			}
+			if errors.Is(err, tracker.ErrUDPDisabled) {
+				a.status = Stopped
+				cancel()
+				return
+			}
 			interval := a.getNextIntervalFromError(a.lastError)
 			resetTimer(interval)
 		case <-a.needMorePeersC:
@@ -288,6 +296,9 @@ func (a *PeriodicalAnnouncer) newAnnounceError(err error) (e *AnnounceError) {
 		return
 	case tracker.ErrDecode:
 		e.Message = "invalid response from tracker"
+		return
+	case tracker.ErrUDPDisabled:
+		e.Message = "udp trackers are disabled"
 		return
 	}
 	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {

--- a/internal/announcer/periodic_test.go
+++ b/internal/announcer/periodic_test.go
@@ -1,0 +1,64 @@
+package announcer
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/rain/v2/internal/logger"
+	"github.com/cenkalti/rain/v2/internal/tracker"
+)
+
+type disabledTracker struct {
+	url string
+}
+
+func (t disabledTracker) Announce(_ context.Context, _ tracker.AnnounceRequest) (*tracker.AnnounceResponse, error) {
+	return nil, tracker.ErrUDPDisabled
+}
+
+func (t disabledTracker) URL() string {
+	return t.url
+}
+
+func TestDisabledTrackerStops(t *testing.T) {
+	trk := disabledTracker{url: "udp://tracker.example.com:6969/announce"}
+	completedC := make(chan struct{})
+	close(completedC)
+	newPeers := make(chan []*net.TCPAddr, 1)
+	getTorrent := func() tracker.Torrent {
+		return tracker.Torrent{
+			Port: 12345,
+		}
+	}
+	an := NewPeriodicalAnnouncer(trk, 50, time.Minute, getTorrent, completedC, newPeers, logger.New("test"))
+
+	// Run should exit on its own after receiving ErrUDPDisabled,
+	// rather than retrying with backoff.
+	done := make(chan struct{})
+	go func() {
+		an.Run()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Run exited — announcer gave up as expected.
+	case <-time.After(5 * time.Second):
+		an.Close()
+		t.Fatal("announcer did not stop after receiving ErrUDPDisabled")
+	}
+
+	// After Run exits, verify the stored state directly (Stats() requires
+	// Run to be active, so we check the exported fields instead).
+	if an.status != Stopped {
+		t.Errorf("expected status Stopped (%d), got %d", Stopped, an.status)
+	}
+	if an.lastError == nil {
+		t.Fatal("expected error in announcer state")
+	}
+	if an.lastError.Message != "udp trackers are disabled" {
+		t.Errorf("expected error message %q, got %q", "udp trackers are disabled", an.lastError.Message)
+	}
+}

--- a/internal/btconn/conn_test.go
+++ b/internal/btconn/conn_test.go
@@ -1,6 +1,7 @@
 package btconn
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestUnencrypted(t *testing.T) {
 	var gerr error
 	go func() {
 		defer close(done)
-		conn, cipher, ext, id, err2 := Dial(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, 10*time.Second, 10*time.Second, false, false, ext1, infoHash, id1, nil)
+		conn, cipher, ext, id, err2 := Dial(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, 10*time.Second, 10*time.Second, false, false, ext1, infoHash, id1, nil, nil)
 		if err2 != nil {
 			gerr = err2
 			return
@@ -83,7 +84,7 @@ func TestEncrypted(t *testing.T) {
 	var gerr error
 	go func() {
 		defer close(done)
-		conn, cipher, ext, id, err2 := Dial(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, 10*time.Second, 10*time.Second, true, true, ext1, infoHash, id1, nil)
+		conn, cipher, ext, id, err2 := Dial(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, 10*time.Second, 10*time.Second, true, true, ext1, infoHash, id1, nil, nil)
 		if err2 != nil {
 			gerr = err2
 			return
@@ -167,5 +168,50 @@ func TestEncrypted(t *testing.T) {
 	<-done
 	if gerr != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCustomDialTimeout(t *testing.T) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	dialTimeout := 2 * time.Second
+	var receivedDeadline bool
+
+	customDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if _, ok := ctx.Deadline(); ok {
+			receivedDeadline = true
+		}
+		var d net.Dialer
+		return d.DialContext(ctx, network, addr)
+	}
+
+	done := make(chan struct{})
+	var gerr error
+	go func() {
+		defer close(done)
+		_, _, _, _, err2 := Dial(
+			&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
+			dialTimeout, 10*time.Second,
+			false, false, ext1, infoHash, id1, nil, customDial)
+		if err2 != nil {
+			gerr = err2
+		}
+	}()
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	Accept(conn, 10*time.Second, nil, false, func(ih [20]byte) bool { return ih == infoHash }, ext2, id2) // nolint: errcheck
+	<-done
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if !receivedDeadline {
+		t.Error("custom dial function did not receive context with deadline")
 	}
 }

--- a/internal/btconn/dial.go
+++ b/internal/btconn/dial.go
@@ -10,6 +10,9 @@ import (
 	"github.com/cenkalti/rain/v2/internal/mse"
 )
 
+// DialFunc is a function that dials a network connection, matching net.Dialer.DialContext signature.
+type DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
 // Dial new connection to the address. Does the BitTorrent protocol handshake.
 // Handles encryption. May try to connect again if encryption does not match with given setting.
 // Returns a net.Conn that is ready for sending/receiving BitTorrent peer protocol messages.
@@ -21,7 +24,8 @@ func Dial(
 	ourExtensions [8]byte,
 	ih [20]byte,
 	ourID [20]byte,
-	stopC chan struct{}) (
+	stopC chan struct{},
+	customDial DialFunc) (
 	conn net.Conn, cipher mse.CryptoMethod, peerExtensions [8]byte, peerID [20]byte, err error) {
 	log := logger.New("conn -> " + addr.String())
 	done := make(chan struct{})
@@ -36,10 +40,17 @@ func Dial(
 		}
 	}()
 
+	dialFn := func(dctx context.Context, network, address string) (net.Conn, error) {
+		if customDial != nil {
+			return customDial(dctx, network, address)
+		}
+		dialer := net.Dialer{Timeout: dialTimeout}
+		return dialer.DialContext(dctx, network, address)
+	}
+
 	// First connection
 	log.Debug("Connecting to peer...")
-	dialer := net.Dialer{Timeout: dialTimeout}
-	conn, err = dialer.DialContext(ctx, addr.Network(), addr.String())
+	conn, err = dialFn(ctx, addr.Network(), addr.String())
 	if err != nil {
 		return
 	}
@@ -97,7 +108,7 @@ func Dial(
 			// Close current connection and try again without encryption
 			conn.Close()
 			log.Debug("Connecting again without encryption...")
-			conn, err = dialer.DialContext(ctx, addr.Network(), addr.String())
+			conn, err = dialFn(ctx, addr.Network(), addr.String())
 			if err != nil {
 				return
 			}

--- a/internal/btconn/dial.go
+++ b/internal/btconn/dial.go
@@ -44,13 +44,15 @@ func Dial(
 	if customDial != nil {
 		dialFn = customDial
 	} else {
-		d := net.Dialer{Timeout: dialTimeout}
+		var d net.Dialer
 		dialFn = d.DialContext
 	}
 
 	// First connection
 	log.Debug("Connecting to peer...")
-	conn, err = dialFn(ctx, addr.Network(), addr.String())
+	dialCtx, dialCancel := context.WithTimeout(ctx, dialTimeout)
+	conn, err = dialFn(dialCtx, addr.Network(), addr.String())
+	dialCancel()
 	if err != nil {
 		return
 	}
@@ -108,7 +110,9 @@ func Dial(
 			// Close current connection and try again without encryption
 			conn.Close()
 			log.Debug("Connecting again without encryption...")
-			conn, err = dialFn(ctx, addr.Network(), addr.String())
+			dialCtx2, dialCancel2 := context.WithTimeout(ctx, dialTimeout)
+			conn, err = dialFn(dialCtx2, addr.Network(), addr.String())
+			dialCancel2()
 			if err != nil {
 				return
 			}

--- a/internal/btconn/dial.go
+++ b/internal/btconn/dial.go
@@ -40,12 +40,12 @@ func Dial(
 		}
 	}()
 
-	dialFn := func(dctx context.Context, network, address string) (net.Conn, error) {
-		if customDial != nil {
-			return customDial(dctx, network, address)
-		}
-		dialer := net.Dialer{Timeout: dialTimeout}
-		return dialer.DialContext(dctx, network, address)
+	var dialFn DialFunc
+	if customDial != nil {
+		dialFn = customDial
+	} else {
+		d := net.Dialer{Timeout: dialTimeout}
+		dialFn = d.DialContext
 	}
 
 	// First connection

--- a/internal/handshaker/outgoinghandshaker/outgoinghandshaker.go
+++ b/internal/handshaker/outgoinghandshaker/outgoinghandshaker.go
@@ -42,11 +42,11 @@ func (h *OutgoingHandshaker) Close() {
 }
 
 // Run the handshaker.
-func (h *OutgoingHandshaker) Run(dialTimeout, handshakeTimeout time.Duration, peerID, infoHash [20]byte, resultC chan *OutgoingHandshaker, ourExtensions [8]byte, disableOutgoingEncryption, forceOutgoingEncryption bool) {
+func (h *OutgoingHandshaker) Run(dialTimeout, handshakeTimeout time.Duration, peerID, infoHash [20]byte, resultC chan *OutgoingHandshaker, ourExtensions [8]byte, disableOutgoingEncryption, forceOutgoingEncryption bool, customDial btconn.DialFunc) {
 	defer close(h.doneC)
 	log := logger.New("peer -> " + h.Addr.String())
 
-	conn, cipher, peerExtensions, peerID, err := btconn.Dial(h.Addr, dialTimeout, handshakeTimeout, !disableOutgoingEncryption, forceOutgoingEncryption, ourExtensions, infoHash, peerID, h.closeC)
+	conn, cipher, peerExtensions, peerID, err := btconn.Dial(h.Addr, dialTimeout, handshakeTimeout, !disableOutgoingEncryption, forceOutgoingEncryption, ourExtensions, infoHash, peerID, h.closeC, customDial)
 	if err != nil {
 		if err == io.EOF {
 			log.Debug("peer has closed the connection: EOF")

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -54,11 +54,10 @@ func ResolveIPv4(ctx context.Context, timeout time.Duration, host string, res *n
 	var cancel func()
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
-	r := res
-	if r == nil {
-		r = net.DefaultResolver
+	if res == nil {
+		res = net.DefaultResolver
 	}
-	addrs, err := r.LookupIPAddr(ctx, host)
+	addrs, err := res.LookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -20,7 +20,7 @@ var (
 )
 
 // Resolve `hostport` to an IPv4 address.
-func Resolve(ctx context.Context, hostport string, timeout time.Duration, bl *blocklist.Blocklist) (net.IP, int, error) {
+func Resolve(ctx context.Context, hostport string, timeout time.Duration, bl *blocklist.Blocklist, res *net.Resolver) (net.IP, int, error) {
 	host, portStr, err := net.SplitHostPort(hostport)
 	if err != nil {
 		return nil, 0, err
@@ -34,7 +34,7 @@ func Resolve(ctx context.Context, hostport string, timeout time.Duration, bl *bl
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {
-		ip, err = ResolveIPv4(ctx, timeout, host)
+		ip, err = ResolveIPv4(ctx, timeout, host, res)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -50,11 +50,15 @@ func Resolve(ctx context.Context, hostport string, timeout time.Duration, bl *bl
 }
 
 // ResolveIPv4 resolves `host` to and IPv4 address.
-func ResolveIPv4(ctx context.Context, timeout time.Duration, host string) (net.IP, error) {
+func ResolveIPv4(ctx context.Context, timeout time.Duration, host string, res *net.Resolver) (net.IP, error) {
 	var cancel func()
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	r := res
+	if r == nil {
+		r = net.DefaultResolver
+	}
+	addrs, err := r.LookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -39,6 +39,9 @@ type AnnounceResponse struct {
 // ErrDecode is returned from Tracker.Announce method when there is problem with the encoding of response.
 var ErrDecode = errors.New("cannot decode response")
 
+// ErrUDPDisabled is returned when a UDP tracker is contacted but UDP trackers are disabled in config.
+var ErrUDPDisabled = errors.New("udp trackers are disabled")
+
 // Error is the string that is sent by the tracker from announce or scrape.
 type Error struct {
 	FailureReason string

--- a/internal/tracker/udptracker/transport.go
+++ b/internal/tracker/udptracker/transport.go
@@ -29,6 +29,7 @@ type Transport struct {
 	blocklist  *blocklist.Blocklist
 	log        logger.Logger
 	dnsTimeout time.Duration
+	resolver   *net.Resolver
 
 	// Transport.Do will send messages to this channel.
 	requestC chan *transportRequest
@@ -44,11 +45,12 @@ type Transport struct {
 }
 
 // NewTransport returns a new UDP tracker transport.
-func NewTransport(bl *blocklist.Blocklist, dnsTimeout time.Duration) *Transport {
+func NewTransport(bl *blocklist.Blocklist, dnsTimeout time.Duration, resolver *net.Resolver) *Transport {
 	return &Transport{
 		blocklist:  bl,
 		log:        logger.New("udp tracker transport"),
 		dnsTimeout: dnsTimeout,
+		resolver:   resolver,
 		requestC:   make(chan *transportRequest),
 		readC:      make(chan []byte),
 		closeC:     make(chan struct{}),
@@ -132,7 +134,7 @@ func (t *Transport) Run() {
 				if err != nil {
 					conn.SetResponse(nil, err)
 				} else {
-					go resolveDestinationAndConnect(trx, req.dest, udpConn, t.dnsTimeout, t.blocklist, connectDone, t.closeC)
+					go resolveDestinationAndConnect(trx, req.dest, udpConn, t.dnsTimeout, t.blocklist, t.resolver, connectDone, t.closeC)
 				}
 			} else {
 				if !conn.connectedAt.IsZero() {
@@ -289,13 +291,13 @@ type connectionResult struct {
 	connectedAt time.Time
 }
 
-func resolveDestinationAndConnect(trx *transaction, dest string, udpConn *net.UDPConn, dnsTimeout time.Duration, blocklist *blocklist.Blocklist, resultC chan *connectionResult, stopC chan struct{}) {
+func resolveDestinationAndConnect(trx *transaction, dest string, udpConn *net.UDPConn, dnsTimeout time.Duration, blocklist *blocklist.Blocklist, dnsResolver *net.Resolver, resultC chan *connectionResult, stopC chan struct{}) {
 	res := &connectionResult{
 		trx:  trx,
 		dest: dest,
 	}
 
-	ip, port, err := resolver.Resolve(trx.ctx, dest, dnsTimeout, blocklist)
+	ip, port, err := resolver.Resolve(trx.ctx, dest, dnsTimeout, blocklist, dnsResolver)
 	if err != nil {
 		res.err = err
 		select {

--- a/internal/tracker/udptracker/udptracker_test.go
+++ b/internal/tracker/udptracker/udptracker_test.go
@@ -55,7 +55,7 @@ func TestUDPTracker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tr := udptracker.NewTransport(nil, 5*time.Second)
+	tr := udptracker.NewTransport(nil, 5*time.Second, nil)
 	go tr.Run()
 	defer tr.Close()
 	trk := udptracker.New(rawURL, u, tr)

--- a/internal/trackermanager/trackermanager.go
+++ b/internal/trackermanager/trackermanager.go
@@ -3,6 +3,7 @@ package trackermanager
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -28,17 +29,19 @@ type TrackerManager struct {
 }
 
 // New returns a new TrackerManager.
-func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool, customDial DialFunc, disableUDPTrackers bool) *TrackerManager {
+func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool, customDial DialFunc, disableUDPTrackers bool, dnsResolver *net.Resolver) *TrackerManager {
 	m := &TrackerManager{
 		httpTransport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: tlsSkipVerify}, // nolint: gosec
 		},
-		udpTransport:       udptracker.NewTransport(bl, dnsTimeout),
 		disableUDPTrackers: disableUDPTrackers,
 	}
-	go m.udpTransport.Run()
+	if !disableUDPTrackers {
+		m.udpTransport = udptracker.NewTransport(bl, dnsTimeout, dnsResolver)
+		go m.udpTransport.Run()
+	}
 	m.httpTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		ip, port, err := resolver.Resolve(ctx, addr, dnsTimeout, bl)
+		ip, port, err := resolver.Resolve(ctx, addr, dnsTimeout, bl, dnsResolver)
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +57,9 @@ func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool, 
 
 func (m *TrackerManager) Close() {
 	m.httpTransport.CloseIdleConnections()
-	m.udpTransport.Close()
+	if m.udpTransport != nil {
+		m.udpTransport.Close()
+	}
 }
 
 // Get a new Tracker implementation from the manager.
@@ -83,7 +88,7 @@ type disabledTracker struct {
 }
 
 func (t disabledTracker) Announce(_ context.Context, _ tracker.AnnounceRequest) (*tracker.AnnounceResponse, error) {
-	return nil, fmt.Errorf("udp trackers are disabled")
+	return nil, errors.New("udp trackers are disabled")
 }
 
 func (t disabledTracker) URL() string {

--- a/internal/trackermanager/trackermanager.go
+++ b/internal/trackermanager/trackermanager.go
@@ -16,6 +16,9 @@ import (
 	"github.com/cenkalti/rain/v2/internal/tracker/udptracker"
 )
 
+// DialFunc is a function that dials a network connection, matching net.Dialer.DialContext signature.
+type DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
 // TrackerManager is a manager for using the same transport for same domains/IPs.
 // Manages both HTTP and UDP trackers.
 type TrackerManager struct {
@@ -24,7 +27,7 @@ type TrackerManager struct {
 }
 
 // New returns a new TrackerManager.
-func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool) *TrackerManager {
+func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool, customDial DialFunc) *TrackerManager {
 	m := &TrackerManager{
 		httpTransport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: tlsSkipVerify}, // nolint: gosec
@@ -37,8 +40,11 @@ func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool) 
 		if err != nil {
 			return nil, err
 		}
-		var d net.Dialer
 		taddr := &net.TCPAddr{IP: ip, Port: port}
+		if customDial != nil {
+			return customDial(ctx, network, taddr.String())
+		}
+		var d net.Dialer
 		return d.DialContext(ctx, network, taddr.String())
 	}
 	return m

--- a/internal/trackermanager/trackermanager.go
+++ b/internal/trackermanager/trackermanager.go
@@ -3,7 +3,6 @@ package trackermanager
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -88,7 +87,7 @@ type disabledTracker struct {
 }
 
 func (t disabledTracker) Announce(_ context.Context, _ tracker.AnnounceRequest) (*tracker.AnnounceResponse, error) {
-	return nil, errors.New("udp trackers are disabled")
+	return nil, tracker.ErrUDPDisabled
 }
 
 func (t disabledTracker) URL() string {

--- a/internal/trackermanager/trackermanager.go
+++ b/internal/trackermanager/trackermanager.go
@@ -22,17 +22,19 @@ type DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 // TrackerManager is a manager for using the same transport for same domains/IPs.
 // Manages both HTTP and UDP trackers.
 type TrackerManager struct {
-	httpTransport *http.Transport
-	udpTransport  *udptracker.Transport
+	httpTransport   *http.Transport
+	udpTransport    *udptracker.Transport
+	disableUDPTrackers bool
 }
 
 // New returns a new TrackerManager.
-func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool, customDial DialFunc) *TrackerManager {
+func New(bl *blocklist.Blocklist, dnsTimeout time.Duration, tlsSkipVerify bool, customDial DialFunc, disableUDPTrackers bool) *TrackerManager {
 	m := &TrackerManager{
 		httpTransport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: tlsSkipVerify}, // nolint: gosec
 		},
-		udpTransport: udptracker.NewTransport(bl, dnsTimeout),
+		udpTransport:       udptracker.NewTransport(bl, dnsTimeout),
+		disableUDPTrackers: disableUDPTrackers,
 	}
 	go m.udpTransport.Run()
 	m.httpTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -66,9 +68,24 @@ func (m *TrackerManager) Get(s string, httpTimeout time.Duration, httpUserAgent 
 		tr := httptracker.New(s, u, httpTimeout, m.httpTransport, httpUserAgent, httpMaxResponseLength)
 		return tr, nil
 	case "udp":
+		if m.disableUDPTrackers {
+			return disabledTracker{url: s}, nil
+		}
 		tr := udptracker.New(s, u, m.udpTransport)
 		return tr, nil
 	default:
 		return nil, fmt.Errorf("unsupported tracker scheme: %s", u.Scheme)
 	}
+}
+
+type disabledTracker struct {
+	url string
+}
+
+func (t disabledTracker) Announce(_ context.Context, _ tracker.AnnounceRequest) (*tracker.AnnounceResponse, error) {
+	return nil, fmt.Errorf("udp trackers are disabled")
+}
+
+func (t disabledTracker) URL() string {
+	return t.url
 }

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -73,6 +73,8 @@ type Config struct {
 	MaxPieces uint32 `yaml:"max-pieces"`
 	// Time to wait when resolving host names for trackers and peers.
 	DNSResolveTimeout time.Duration `yaml:"dns-resolve-timeout"`
+	// TLS handshake timeout for general HTTP requests (blocklist downloads, torrent URL fetching).
+	TLSHandshakeTimeout time.Duration `yaml:"tls-handshake-timeout"`
 	// Global download speed limit in KB/s.
 	SpeedLimitDownload int64 `yaml:"speed-limit-download"`
 	// Global upload speed limit in KB/s.
@@ -249,6 +251,7 @@ var DefaultConfig = Config{
 	MaxTorrentSize:                         10 << 20,
 	MaxPieces:                              64 << 10,
 	DNSResolveTimeout:                      5 * time.Second,
+	TLSHandshakeTimeout:                    10 * time.Second,
 	ResumeOnStartup:                        true,
 	HealthCheckInterval:                    10 * time.Second,
 	HealthCheckTimeout:                     60 * time.Second,

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -212,6 +212,7 @@ type Config struct {
 	// CustomDialFunc, if set, is used for all outbound TCP connections
 	// (peer connections, HTTP tracker connections, webseed connections,
 	// torrent URL fetching, and blocklist downloads).
+	// DNS resolution is also routed through this transport when set.
 	// This allows routing traffic through a custom network transport (e.g. an embedded VPN).
 	// The function signature matches net.Dialer.DialContext.
 	// Note: DHT and UDP tracker traffic use UDP sockets and cannot be routed through this function.

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -208,9 +208,11 @@ type Config struct {
 	CustomStorage storage.Provider `yaml:"-"`
 
 	// CustomDialFunc, if set, is used for all outbound TCP connections
-	// (peer connections, tracker HTTP connections, webseed connections).
-	// This allows routing traffic through a custom network transport.
+	// (peer connections, HTTP tracker connections, webseed connections,
+	// torrent URL fetching, and blocklist downloads).
+	// This allows routing traffic through a custom network transport (e.g. an embedded VPN).
 	// The function signature matches net.Dialer.DialContext.
+	// Note: DHT and UDP tracker traffic use UDP sockets and are not affected by this setting.
 	CustomDialFunc func(ctx context.Context, network, addr string) (net.Conn, error) `yaml:"-"`
 
 	// Enable debugging

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -1,7 +1,9 @@
 package torrent
 
 import (
+	"context"
 	"io/fs"
+	"net"
 	"time"
 
 	"github.com/cenkalti/log"
@@ -204,6 +206,12 @@ type Config struct {
 	CustomLogHandler log.Handler `yaml:"-"`
 	// Replace default storage provider
 	CustomStorage storage.Provider `yaml:"-"`
+
+	// CustomDialFunc, if set, is used for all outbound TCP connections
+	// (peer connections, tracker HTTP connections, webseed connections).
+	// This allows routing traffic through a custom network transport.
+	// The function signature matches net.Dialer.DialContext.
+	CustomDialFunc func(ctx context.Context, network, addr string) (net.Conn, error) `yaml:"-"`
 
 	// Enable debugging
 	Debug bool `yaml:"debug"`

--- a/torrent/config.go
+++ b/torrent/config.go
@@ -127,6 +127,8 @@ type Config struct {
 	TrackerHTTPMaxResponseSize uint `yaml:"tracker-http-max-response-size"`
 	// Check and validate TLS ceritificates.
 	TrackerHTTPVerifyTLS bool `yaml:"tracker-http-verify-tls"`
+	// Disable sending announces to UDP trackers.
+	DisableUDPTrackers bool `yaml:"disable-udp-trackers"`
 
 	// Number of unchoked peers.
 	UnchokedPeers int `yaml:"unchoked-peers"`
@@ -212,7 +214,9 @@ type Config struct {
 	// torrent URL fetching, and blocklist downloads).
 	// This allows routing traffic through a custom network transport (e.g. an embedded VPN).
 	// The function signature matches net.Dialer.DialContext.
-	// Note: DHT and UDP tracker traffic use UDP sockets and are not affected by this setting.
+	// Note: DHT and UDP tracker traffic use UDP sockets and cannot be routed through this function.
+	// To prevent any traffic from leaking outside the custom network, also set
+	// DHTEnabled=false and DisableUDPTrackers=true.
 	CustomDialFunc func(ctx context.Context, network, addr string) (net.Conn, error) `yaml:"-"`
 
 	// Enable debugging

--- a/torrent/custom_dial_test.go
+++ b/torrent/custom_dial_test.go
@@ -13,11 +13,9 @@ import (
 )
 
 func TestCustomDialFuncNoLeak(t *testing.T) {
-	// Start an HTTP tracker so the torrent has something to announce to.
-	startHTTPTracker(t)
-
-	// Set up a seeder with a normal session (no custom dial) that has the data.
-	seederAddr := seeder(t, false)
+	// Set up a seeder without trackers — we only need peer connections to verify
+	// that CustomDialFunc captures all outbound TCP.
+	seederAddr := seeder(t, true)
 
 	// Track all connections made through the custom dial function.
 	var mu sync.Mutex
@@ -46,11 +44,10 @@ func TestCustomDialFuncNoLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := s.Close(); err != nil {
-			t.Fatal(err)
-		}
-	})
+	// Close the session explicitly before returning so that stop-announces
+	// complete while the HTTP tracker is still running, avoiding a data race
+	// in chihaya's peerStore during concurrent cleanup.
+	defer s.Close()
 
 	// Add the torrent and start downloading.
 	f, err := os.Open(torrentFile)

--- a/torrent/custom_dial_test.go
+++ b/torrent/custom_dial_test.go
@@ -1,0 +1,183 @@
+package torrent
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	cp "github.com/otiai10/copy"
+)
+
+func TestCustomDialFuncNoLeak(t *testing.T) {
+	// Start an HTTP tracker so the torrent has something to announce to.
+	startHTTPTracker(t)
+
+	// Set up a seeder with a normal session (no custom dial) that has the data.
+	seederAddr := seeder(t, false)
+
+	// Track all connections made through the custom dial function.
+	var mu sync.Mutex
+	var dialedAddrs []string
+	customDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		mu.Lock()
+		dialedAddrs = append(dialedAddrs, addr)
+		mu.Unlock()
+		var d net.Dialer
+		return d.DialContext(ctx, network, addr)
+	}
+
+	// Create a leecher session with CustomDialFunc and UDP trackers disabled.
+	tmp := t.TempDir()
+	cfg := DefaultConfig
+	cfg.Database = filepath.Join(tmp, "session.db")
+	cfg.DataDir = tmp
+	cfg.DHTEnabled = false
+	cfg.PEXEnabled = false
+	cfg.RPCEnabled = false
+	cfg.Host = "127.0.0.1"
+	cfg.CustomDialFunc = customDial
+	cfg.DisableUDPTrackers = true
+
+	s, err := NewSession(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Add the torrent and start downloading.
+	f, err := os.Open(torrentFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	tor, err := s.AddTorrent(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Also add the seeder as a direct peer so the download can complete.
+	tor.AddPeer(seederAddr)
+
+	assertCompleted(t, tor)
+
+	mu.Lock()
+	addrs := make([]string, len(dialedAddrs))
+	copy(addrs, dialedAddrs)
+	mu.Unlock()
+
+	if len(addrs) == 0 {
+		t.Fatal("custom dial function was never called — all connections bypassed it")
+	}
+
+	// Verify that every dialed address is a loopback address (127.0.0.1).
+	// In this test, the only reachable services are on localhost (tracker + seeder).
+	// If any connection went to a non-loopback address, something leaked.
+	for _, addr := range addrs {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			t.Errorf("unexpected address format: %s", addr)
+			continue
+		}
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			t.Errorf("connection to non-loopback address bypassed custom dial: %s", addr)
+		}
+	}
+
+	t.Logf("custom dial handled %d connections", len(addrs))
+}
+
+func TestDisabledUDPTrackerStatus(t *testing.T) {
+	// Set up a seeder with data so the torrent can start its event loop.
+	seederAddr := seeder(t, true)
+
+	// Create a session with UDP trackers disabled.
+	tmp := t.TempDir()
+	cfg := DefaultConfig
+	cfg.Database = filepath.Join(tmp, "session.db")
+	cfg.DataDir = tmp
+	cfg.DHTEnabled = false
+	cfg.PEXEnabled = false
+	cfg.RPCEnabled = false
+	cfg.Host = "127.0.0.1"
+	cfg.DisableUDPTrackers = true
+
+	s, err := NewSession(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Add torrent stopped, then inject a UDP tracker URL and start.
+	f, err := os.Open(torrentFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	opt := &AddTorrentOptions{Stopped: true}
+	tor, err := s.AddTorrent(f, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy the data so the torrent has something to seed (prevents error state).
+	src := filepath.Join(torrentDataDir, torrentName)
+	dst := filepath.Join(s.config.DataDir, tor.ID(), torrentName)
+	err = os.Mkdir(filepath.Join(s.config.DataDir, tor.ID()), os.ModeDir|s.config.FilePermissions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cp.Copy(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace trackers with a UDP-only tracker URL.
+	tor.torrent.trackers = s.parseTrackers([][]string{{"udp://tracker.example.com:6969/announce"}}, false)
+
+	tor.Start()
+	tor.AddPeer(seederAddr)
+
+	// Wait for the torrent to start and the announcer to process.
+	waitForStart(t, tor)
+
+	// Give the announcer time to attempt the announce and stop.
+	time.Sleep(500 * time.Millisecond)
+
+	trackers := tor.Trackers()
+	if len(trackers) == 0 {
+		t.Fatal("expected at least one tracker")
+	}
+
+	found := false
+	for _, tr := range trackers {
+		if tr.URL == "udp://tracker.example.com:6969/announce" {
+			found = true
+			if tr.Status != TrackerStopped {
+				t.Errorf("expected tracker status TrackerStopped (%d), got %d", TrackerStopped, tr.Status)
+			}
+			if tr.Error == nil {
+				t.Error("expected error on disabled tracker")
+			} else if tr.Error.Error() != "udp trackers are disabled" {
+				t.Errorf("expected error %q, got %q", "udp trackers are disabled", tr.Error.Error())
+			}
+		}
+	}
+	if !found {
+		t.Error("UDP tracker not found in tracker list")
+	}
+}

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -167,7 +167,7 @@ func NewSession(cfg Config) (*Session, error) {
 		db:                 db,
 		resumer:            res,
 		blocklist:          bl,
-		trackerManager:     trackermanager.New(blTracker, cfg.DNSResolveTimeout, !cfg.TrackerHTTPVerifyTLS),
+		trackerManager:     trackermanager.New(blTracker, cfg.DNSResolveTimeout, !cfg.TrackerHTTPVerifyTLS, trackermanager.DialFunc(cfg.CustomDialFunc)),
 		log:                l,
 		torrents:           make(map[string]*Torrent),
 		torrentsByInfoHash: make(map[dht.InfoHash][]*Torrent),
@@ -185,8 +185,13 @@ func NewSession(cfg Config) (*Session, error) {
 					if err != nil {
 						return nil, err
 					}
-					var d net.Dialer
 					taddr := &net.TCPAddr{IP: ip, Port: port}
+					if cfg.CustomDialFunc != nil {
+						dctx, cancel := context.WithTimeout(ctx, cfg.WebseedDialTimeout)
+						defer cancel()
+						return cfg.CustomDialFunc(dctx, network, taddr.String())
+					}
+					var d net.Dialer
 					dctx, cancel := context.WithTimeout(ctx, cfg.WebseedDialTimeout)
 					defer cancel()
 					return d.DialContext(dctx, network, taddr.String())

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -166,6 +166,11 @@ func NewSession(cfg Config) (*Session, error) {
 	var customResolver *net.Resolver
 	if cfg.CustomDialFunc != nil {
 		customResolver = &net.Resolver{
+			// PreferGo forces the pure-Go resolver. Without this, Go may use
+			// the cgo resolver (libc getaddrinfo) under certain system configurations
+			// (e.g. nsswitch.conf features, LOCALDOMAIN env var), which bypasses
+			// our custom Dial function and leaks DNS outside the custom transport.
+			PreferGo: true,
 			Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return cfg.CustomDialFunc(ctx, network, addr)
 			},

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -186,14 +186,12 @@ func NewSession(cfg Config) (*Session, error) {
 						return nil, err
 					}
 					taddr := &net.TCPAddr{IP: ip, Port: port}
+					dctx, cancel := context.WithTimeout(ctx, cfg.WebseedDialTimeout)
+					defer cancel()
 					if cfg.CustomDialFunc != nil {
-						dctx, cancel := context.WithTimeout(ctx, cfg.WebseedDialTimeout)
-						defer cancel()
 						return cfg.CustomDialFunc(dctx, network, taddr.String())
 					}
 					var d net.Dialer
-					dctx, cancel := context.WithTimeout(ctx, cfg.WebseedDialTimeout)
-					defer cancel()
 					return d.DialContext(dctx, network, taddr.String())
 				},
 				TLSHandshakeTimeout:   cfg.WebseedTLSHandshakeTimeout,

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -42,6 +42,7 @@ var (
 // Session contains torrents, DHT node, caches and other data structures shared by multiple torrents.
 type Session struct {
 	config         Config
+	customResolver *net.Resolver
 	db             *bbolt.DB
 	storage        storage.Provider
 	resumer        *boltdbresumer.Resumer
@@ -162,12 +163,21 @@ func NewSession(cfg Config) (*Session, error) {
 	if cfg.BlocklistEnabledForTrackers {
 		blTracker = bl
 	}
+	var customResolver *net.Resolver
+	if cfg.CustomDialFunc != nil {
+		customResolver = &net.Resolver{
+			Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return cfg.CustomDialFunc(ctx, network, addr)
+			},
+		}
+	}
 	c := &Session{
 		config:             cfg,
+		customResolver:     customResolver,
 		db:                 db,
 		resumer:            res,
 		blocklist:          bl,
-		trackerManager:     trackermanager.New(blTracker, cfg.DNSResolveTimeout, !cfg.TrackerHTTPVerifyTLS, trackermanager.DialFunc(cfg.CustomDialFunc), cfg.DisableUDPTrackers),
+		trackerManager:     trackermanager.New(blTracker, cfg.DNSResolveTimeout, !cfg.TrackerHTTPVerifyTLS, trackermanager.DialFunc(cfg.CustomDialFunc), cfg.DisableUDPTrackers, customResolver),
 		log:                l,
 		torrents:           make(map[string]*Torrent),
 		torrentsByInfoHash: make(map[dht.InfoHash][]*Torrent),
@@ -181,7 +191,7 @@ func NewSession(cfg Config) (*Session, error) {
 		webseedClient: http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-					ip, port, err := resolver.Resolve(ctx, addr, cfg.DNSResolveTimeout, bl)
+					ip, port, err := resolver.Resolve(ctx, addr, cfg.DNSResolveTimeout, bl, customResolver)
 					if err != nil {
 						return nil, err
 					}

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -167,7 +167,7 @@ func NewSession(cfg Config) (*Session, error) {
 		db:                 db,
 		resumer:            res,
 		blocklist:          bl,
-		trackerManager:     trackermanager.New(blTracker, cfg.DNSResolveTimeout, !cfg.TrackerHTTPVerifyTLS, trackermanager.DialFunc(cfg.CustomDialFunc)),
+		trackerManager:     trackermanager.New(blTracker, cfg.DNSResolveTimeout, !cfg.TrackerHTTPVerifyTLS, trackermanager.DialFunc(cfg.CustomDialFunc), cfg.DisableUDPTrackers),
 		log:                l,
 		torrents:           make(map[string]*Torrent),
 		torrentsByInfoHash: make(map[dht.InfoHash][]*Torrent),

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -161,6 +161,9 @@ func (s *Session) addURL(u string, opt *AddTorrentOptions) (*Torrent, error) {
 	client := http.Client{
 		Timeout: s.config.TorrentAddHTTPTimeout,
 	}
+	if s.config.CustomDialFunc != nil {
+		client.Transport = &http.Transport{DialContext: s.config.CustomDialFunc}
+	}
 	resp, err := client.Get(u) // nolint: noctx
 	if err != nil {
 		return nil, newInputError(err)

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -164,7 +164,7 @@ func (s *Session) addURL(u string, opt *AddTorrentOptions) (*Torrent, error) {
 	if s.config.CustomDialFunc != nil {
 		client.Transport = &http.Transport{
 			DialContext:          s.config.CustomDialFunc,
-			TLSHandshakeTimeout: 10 * time.Second,
+			TLSHandshakeTimeout: s.config.TLSHandshakeTimeout,
 		}
 	}
 	resp, err := client.Get(u) // nolint: noctx

--- a/torrent/session_add.go
+++ b/torrent/session_add.go
@@ -162,7 +162,10 @@ func (s *Session) addURL(u string, opt *AddTorrentOptions) (*Torrent, error) {
 		Timeout: s.config.TorrentAddHTTPTimeout,
 	}
 	if s.config.CustomDialFunc != nil {
-		client.Transport = &http.Transport{DialContext: s.config.CustomDialFunc}
+		client.Transport = &http.Transport{
+			DialContext:          s.config.CustomDialFunc,
+			TLSHandshakeTimeout: 10 * time.Second,
+		}
 	}
 	resp, err := client.Get(u) // nolint: noctx
 	if err != nil {

--- a/torrent/session_blocklist.go
+++ b/torrent/session_blocklist.go
@@ -119,6 +119,9 @@ func (s *Session) reloadBlocklist() error {
 	client := http.Client{
 		Timeout: s.config.BlocklistUpdateTimeout,
 	}
+	if s.config.CustomDialFunc != nil {
+		client.Transport = &http.Transport{DialContext: s.config.CustomDialFunc}
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/torrent/session_blocklist.go
+++ b/torrent/session_blocklist.go
@@ -122,7 +122,7 @@ func (s *Session) reloadBlocklist() error {
 	if s.config.CustomDialFunc != nil {
 		client.Transport = &http.Transport{
 			DialContext:          s.config.CustomDialFunc,
-			TLSHandshakeTimeout: 10 * time.Second,
+			TLSHandshakeTimeout: s.config.TLSHandshakeTimeout,
 		}
 	}
 

--- a/torrent/session_blocklist.go
+++ b/torrent/session_blocklist.go
@@ -120,7 +120,10 @@ func (s *Session) reloadBlocklist() error {
 		Timeout: s.config.BlocklistUpdateTimeout,
 	}
 	if s.config.CustomDialFunc != nil {
-		client.Transport = &http.Transport{DialContext: s.config.CustomDialFunc}
+		client.Transport = &http.Transport{
+			DialContext:          s.config.CustomDialFunc,
+			TLSHandshakeTimeout: 10 * time.Second,
+		}
 	}
 
 	resp, err := client.Do(req)

--- a/torrent/torrent_commands.go
+++ b/torrent/torrent_commands.go
@@ -178,6 +178,8 @@ const (
 	Working
 	// NotWorking indicates that the tracker didn't respond or returned an error.
 	NotWorking
+	// TrackerStopped indicates the tracker is permanently disabled and will not be contacted.
+	TrackerStopped
 )
 
 func trackerStatusToString(s TrackerStatus) string {
@@ -186,6 +188,7 @@ func trackerStatusToString(s TrackerStatus) string {
 		Contacting:      "Contacting",
 		Working:         "Working",
 		NotWorking:      "Not working",
+		TrackerStopped:  "Stopped",
 	}
 	return m[s]
 }

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -108,10 +108,7 @@ func (t *torrent) dialAddresses() {
 		h := outgoinghandshaker.New(addr, src)
 		t.outgoingHandshakers[h] = struct{}{}
 		t.connectedPeerIPs[ip] = struct{}{}
-		var customDial btconn.DialFunc
-		if t.session.config.CustomDialFunc != nil {
-			customDial = btconn.DialFunc(t.session.config.CustomDialFunc)
-		}
+		customDial := btconn.DialFunc(t.session.config.CustomDialFunc)
 		go h.Run(
 			t.session.config.PeerConnectTimeout,
 			t.session.config.PeerHandshakeTimeout,

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -57,7 +57,7 @@ func (t *torrent) resolveAndAddPeer(host string, port int) {
 		}
 		cancel()
 	}()
-	ip, err := resolver.ResolveIPv4(ctx, t.session.config.DNSResolveTimeout, host)
+	ip, err := resolver.ResolveIPv4(ctx, t.session.config.DNSResolveTimeout, host, t.session.customResolver)
 	if err != nil {
 		return
 	}

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/cenkalti/rain/v2/internal/bitfield"
+	"github.com/cenkalti/rain/v2/internal/btconn"
 	"github.com/cenkalti/rain/v2/internal/handshaker/outgoinghandshaker"
 	"github.com/cenkalti/rain/v2/internal/mse"
 	"github.com/cenkalti/rain/v2/internal/peer"
@@ -107,6 +108,10 @@ func (t *torrent) dialAddresses() {
 		h := outgoinghandshaker.New(addr, src)
 		t.outgoingHandshakers[h] = struct{}{}
 		t.connectedPeerIPs[ip] = struct{}{}
+		var customDial btconn.DialFunc
+		if t.session.config.CustomDialFunc != nil {
+			customDial = btconn.DialFunc(t.session.config.CustomDialFunc)
+		}
 		go h.Run(
 			t.session.config.PeerConnectTimeout,
 			t.session.config.PeerHandshakeTimeout,
@@ -116,6 +121,7 @@ func (t *torrent) dialAddresses() {
 			t.session.extensions,
 			t.session.config.DisableOutgoingEncryption,
 			t.session.config.ForceOutgoingEncryption,
+			customDial,
 		)
 	}
 }

--- a/torrent/torrent_test.go
+++ b/torrent/torrent_test.go
@@ -186,6 +186,13 @@ func TestTorrentFiles(t *testing.T) {
 	assertCompleted(t, tor)
 }
 
+// startHTTPTracker starts a chihaya HTTP tracker on 127.0.0.1:5000.
+//
+// Known issue: chihaya's HTTP frontend spawns fire-and-forget goroutines for
+// AfterAnnounce (frontend/http/frontend.go:341) that are not tracked by any
+// WaitGroup. This causes a data race between peerStore.Stop() and in-flight
+// AfterAnnounce goroutines during test cleanup. The time.Sleep below is a
+// best-effort workaround; a proper fix requires patching chihaya.
 func startHTTPTracker(t *testing.T) {
 	t.Helper()
 	responseConfig := middleware.ResponseConfig{


### PR DESCRIPTION
This PR allows Rain-as-a-Library users to route all outbound TCP connections and DNS resolution through an optional custom dial function, enabling use cases like embedded VPNs. Also adds configurable TLS handshake timeouts, a UDP tracker disable option with clean announcer shutdown, and minor resolver cleanup.

This changeset was semi-vibecoded by someone who is new to this codebase, new to AI-assisted coding, but very experienced with Go. **Manual review is recommended.**

I'm still testing this manually, so I'm leaving this PR in draft state for now, but it's open for feedback. I'm happy to do whatever grunt work is needed to polish this up. I will keep an eye on edits from maintainers - go ahead and do it, I will pull.

Everything below this line was written by an LLM when asked to summarize the changeset.

## Summary

- Add `CustomDialFunc` config option to route all outbound TCP connections (peer connections, HTTP trackers, webseeds, blocklist downloads, torrent URL fetching) through a custom dialer, enabling use cases like embedded VPNs
- Route DNS resolution through the custom transport via `net.Resolver` with `PreferGo: true` to prevent DNS leaks on systems where Go might fall back to the cgo resolver
- Add `DisableUDPTrackers` config option since UDP traffic cannot be routed through the custom dialer; disabled UDP trackers are represented as a `disabledTracker` that returns `tracker.ErrUDPDisabled`, and the announcer permanently stops retrying (new `Stopped` status) instead of logging errors and backing off indefinitely
- Add `TLSHandshakeTimeout` config option (default 10s) replacing hardcoded timeouts in blocklist download and torrent URL fetch HTTP clients
- Simplify resolver by using the `res` parameter directly instead of shadowing it with a local variable

## Test plan

- [x] `go build ./...` passes
- [x] Existing tests pass (`internal/announcer`, `internal/tracker/...`, `internal/trackermanager`)
- [x] New `TestCustomDialTimeout` verifies the custom dial function receives a context with deadline
- [x] New `TestCustomDialFuncNoLeak` verifies all TCP connections go through the custom dial function during a full download
- [x] New `TestDisabledUDPTrackerStatus` verifies UDP trackers show `TrackerStopped` status with correct error via the `Trackers()` API