### PR TITLE
Bug fixes: BEP-47/webseed, concurrency, and DoS hardening

### DIFF
--- a/internal/addrlist/addrlist.go
+++ b/internal/addrlist/addrlist.go
@@ -114,7 +114,6 @@ func (d *AddrList) Push(addrs []*net.TCPAddr, source peersource.Source) {
 	if delta > 0 {
 		d.removeExcessItems(delta)
 		d.filterNils()
-		d.countBySource[source] -= delta
 	}
 	if len(d.peerByTime) != d.peerByPriority.Len() {
 		panic("addr list data structures not in sync")
@@ -134,6 +133,7 @@ func (d *AddrList) filterNils() {
 
 func (d *AddrList) removeExcessItems(delta int) {
 	for i := range delta {
+		d.countBySource[d.peerByTime[i].source]--
 		d.peerByPriority.Delete(d.peerByTime[i])
 		d.peerByTime[i] = nil
 	}

--- a/internal/addrlist/addrlist_test.go
+++ b/internal/addrlist/addrlist_test.go
@@ -53,6 +53,28 @@ func TestAddrList(t *testing.T) {
 	assert.Equal(t, al.peerByTime[1].index, 1)
 }
 
+// TestCountBySourceEviction verifies that per-source counts stay accurate when
+// pushing peers evicts older peers belonging to a different source.
+func TestCountBySourceEviction(t *testing.T) {
+	clientIP := net.IPv4(1, 2, 3, 4)
+	al := New(2, nil, 5000, &clientIP)
+
+	// Fill the list with 2 DHT peers (list is now full: maxItems == 2).
+	al.Push([]*net.TCPAddr{newAddr("1.1.1.1"), newAddr("2.2.2.2")}, peersource.DHT)
+	assert.Equal(t, 2, al.LenSource(peersource.DHT))
+	assert.Equal(t, 0, al.LenSource(peersource.Tracker))
+
+	// Push 2 Tracker peers. They are newer, so the 2 older DHT peers get
+	// evicted and the list ends up holding only the 2 Tracker peers.
+	al.Push([]*net.TCPAddr{newAddr("3.3.3.3"), newAddr("4.4.4.4")}, peersource.Tracker)
+	assert.Equal(t, 2, al.Len())
+	assert.Equal(t, 2, al.LenSource(peersource.Tracker))
+	assert.Equal(t, 0, al.LenSource(peersource.DHT))
+
+	// Per-source counts must always sum to the total list length.
+	assert.Equal(t, al.Len(), al.LenSource(peersource.Tracker)+al.LenSource(peersource.DHT))
+}
+
 func newAddr(ip string) *net.TCPAddr {
 	return &net.TCPAddr{IP: net.ParseIP(ip), Port: 1}
 }

--- a/internal/filesection/section.go
+++ b/internal/filesection/section.go
@@ -64,6 +64,9 @@ func (p Piece) Write(b []byte) (n int, err error) {
 	var m int
 	for _, sec := range p {
 		if sec.Padding {
+			// Padding bytes are present in the buffer but not written to any
+			// file, so skip over them to keep the rest of the sections aligned.
+			b = b[sec.Length:]
 			continue
 		}
 		m, err = sec.File.WriteAt(b[:sec.Length], sec.Offset)

--- a/internal/metainfo/info.go
+++ b/internal/metainfo/info.go
@@ -160,17 +160,20 @@ func NewInfo(b []byte, utf8 bool, pad bool) (*Info, error) {
 				parts = append(parts, cleanName(p))
 			}
 			joinedPath := filepath.Join(parts...)
-			if _, ok := uniquePaths[joinedPath]; ok {
-				return nil, fmt.Errorf("duplicate file name: %q", joinedPath)
-			} else {
+			isPadding := pad && f.isPadding()
+			// Padding files are never written to disk, so conflicting paths
+			// are harmless. BEP 47 even recommends that pad files share the
+			// same ".pad/<length>" path, so duplicates are common.
+			if !isPadding {
+				if _, ok := uniquePaths[joinedPath]; ok {
+					return nil, fmt.Errorf("duplicate file name: %q", joinedPath)
+				}
 				uniquePaths[joinedPath] = nil
 			}
 			i.Files[j] = File{
-				Path:   joinedPath,
-				Length: f.Length,
-			}
-			if pad {
-				i.Files[j].Padding = f.isPadding()
+				Path:    joinedPath,
+				Length:  f.Length,
+				Padding: isPadding,
 			}
 		}
 	} else {

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -84,7 +84,7 @@ type PieceMessage struct {
 }
 
 // New wraps the net.Conn and returns a new Peer.
-func New(conn net.Conn, source peersource.Source, id [20]byte, extensions [8]byte, cipher mse.CryptoMethod, pieceReadTimeout, snubTimeout time.Duration, maxRequestsIn int, br, bw *ratelimit.Bucket) *Peer {
+func New(conn net.Conn, source peersource.Source, id [20]byte, extensions [8]byte, cipher mse.CryptoMethod, pieceReadTimeout, snubTimeout time.Duration, maxRequestsIn, maxMsgSize int, br, bw *ratelimit.Bucket) *Peer {
 	bf, _ := bitfield.NewBytes(extensions[:], 64)
 	fastEnabled := bf.Test(61)
 	extensionsEnabled := bf.Test(43)
@@ -93,7 +93,7 @@ func New(conn net.Conn, source peersource.Source, id [20]byte, extensions [8]byt
 	t := time.NewTimer(math.MaxInt64)
 	t.Stop()
 	return &Peer{
-		Conn:              peerconn.New(conn, newPeerLogger(source, conn), pieceReadTimeout, maxRequestsIn, fastEnabled, br, bw),
+		Conn:              peerconn.New(conn, newPeerLogger(source, conn), pieceReadTimeout, maxRequestsIn, maxMsgSize, fastEnabled, br, bw),
 		Source:            source,
 		ConnectedAt:       time.Now(),
 		ID:                id,

--- a/internal/peerconn/peerconn.go
+++ b/internal/peerconn/peerconn.go
@@ -24,10 +24,10 @@ type Conn struct {
 }
 
 // New returns a new PeerConn by wrapping a net.Conn.
-func New(conn net.Conn, l logger.Logger, pieceTimeout time.Duration, maxRequestsIn int, fastEnabled bool, br, bw *ratelimit.Bucket) *Conn {
+func New(conn net.Conn, l logger.Logger, pieceTimeout time.Duration, maxRequestsIn, maxMsgSize int, fastEnabled bool, br, bw *ratelimit.Bucket) *Conn {
 	return &Conn{
 		conn:     conn,
-		reader:   peerreader.New(conn, l, pieceTimeout, br),
+		reader:   peerreader.New(conn, l, pieceTimeout, maxMsgSize, br),
 		writer:   peerwriter.New(conn, l, maxRequestsIn, fastEnabled, bw),
 		messages: make(chan any),
 		log:      l,

--- a/internal/peerconn/peerreader/peerreader.go
+++ b/internal/peerconn/peerreader/peerreader.go
@@ -33,6 +33,7 @@ type PeerReader struct {
 	r            io.Reader
 	log          logger.Logger
 	pieceTimeout time.Duration
+	maxMsgSize   int
 	bucket       *ratelimit.Bucket
 	messages     chan any
 	stopC        chan struct{}
@@ -40,12 +41,15 @@ type PeerReader struct {
 }
 
 // New returns a new PeerReader by wrapping a net.Conn.
-func New(conn net.Conn, l logger.Logger, pieceTimeout time.Duration, b *ratelimit.Bucket) *PeerReader {
+// maxMsgSize is the largest message length accepted from the peer; larger
+// messages are rejected before allocating a buffer for them.
+func New(conn net.Conn, l logger.Logger, pieceTimeout time.Duration, maxMsgSize int, b *ratelimit.Bucket) *PeerReader {
 	return &PeerReader{
 		conn:         conn,
 		r:            bufio.NewReaderSize(conn, readBufferSize),
 		log:          l,
 		pieceTimeout: pieceTimeout,
+		maxMsgSize:   maxMsgSize,
 		bucket:       b,
 		messages:     make(chan any),
 		stopC:        make(chan struct{}),
@@ -123,6 +127,15 @@ func (p *PeerReader) Run() {
 		length--
 
 		// p.log.Debugf("Received message of type: %q", id)
+
+		// Reject oversized messages before allocating a buffer for them. The
+		// remaining variable-length messages (bitfield, extension) size a buffer
+		// directly from this attacker-controlled length, so without this an
+		// untrusted peer could force an arbitrarily large allocation.
+		if int64(length) > int64(p.maxMsgSize) {
+			err = fmt.Errorf("received message larger than allowed (%d > %d)", length, p.maxMsgSize)
+			return
+		}
 
 		var msg any
 

--- a/internal/peerconn/peerreader/peerreader_test.go
+++ b/internal/peerconn/peerreader/peerreader_test.go
@@ -1,0 +1,77 @@
+package peerreader
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/rain/v2/internal/logger"
+	"github.com/cenkalti/rain/v2/internal/peerprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// header builds the 4-byte length prefix and 1-byte message ID for a message
+// whose body is bodyLen bytes long. The body itself is not included.
+func header(id peerprotocol.MessageID, bodyLen int) []byte {
+	b := make([]byte, 5)
+	binary.BigEndian.PutUint32(b[:4], uint32(1+bodyLen))
+	b[4] = byte(id)
+	return b
+}
+
+func TestRejectsOversizedMessage(t *testing.T) {
+	const maxMsgSize = 100
+
+	server, client := net.Pipe()
+	defer client.Close()
+
+	r := New(server, logger.New("test"), time.Minute, maxMsgSize, nil)
+	go r.Run()
+
+	// Announce a bitfield far larger than the limit, but send no body. Without
+	// the size guard the reader would allocate the buffer and block in
+	// io.ReadFull until the read deadline; with the guard it returns at once.
+	go func() {
+		_, _ = client.Write(header(peerprotocol.Bitfield, maxMsgSize+1))
+	}()
+
+	select {
+	case <-r.Done():
+	case msg := <-r.Messages():
+		t.Fatalf("oversized message was not rejected: got %T", msg)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader did not reject oversized message")
+	}
+}
+
+func TestAcceptsMessageAtLimit(t *testing.T) {
+	const maxMsgSize = 100
+
+	server, client := net.Pipe()
+
+	r := New(server, logger.New("test"), time.Minute, maxMsgSize, nil)
+	go r.Run()
+	defer func() {
+		// Close the conn first so the reader's pending Read returns at once,
+		// instead of waiting for the read deadline.
+		client.Close()
+		<-r.Done()
+	}()
+
+	body := []byte{0xAB, 0xCD}
+	go func() {
+		_, _ = client.Write(header(peerprotocol.Bitfield, len(body)))
+		_, _ = client.Write(body)
+	}()
+
+	select {
+	case msg := <-r.Messages():
+		bm, ok := msg.(peerprotocol.BitfieldMessage)
+		require.True(t, ok, "expected BitfieldMessage, got %T", msg)
+		assert.Equal(t, body, bm.Data)
+	case <-time.After(5 * time.Second):
+		t.Fatal("valid message under the limit was not delivered")
+	}
+}

--- a/internal/peerprotocol/extension.go
+++ b/internal/peerprotocol/extension.go
@@ -84,13 +84,13 @@ func (m *ExtensionMessage) UnmarshalBinary(data []byte) error {
 	case ExtensionIDHandshake:
 		var extMsg ExtensionHandshakeMessage
 		err = dec.Decode(&extMsg)
-		m.Payload = extMsg
 		if extMsg.MetadataSize < 0 {
 			extMsg.MetadataSize = 0
 		}
 		if extMsg.RequestQueue < 0 {
 			extMsg.RequestQueue = 0
 		}
+		m.Payload = extMsg
 	case ExtensionIDMetadata:
 		var extMsg ExtensionMetadataMessage
 		err = dec.Decode(&extMsg)

--- a/internal/piecepicker/piecepicker.go
+++ b/internal/piecepicker/piecepicker.go
@@ -182,6 +182,7 @@ func (p *PiecePicker) HandleUnchoke(pe *peer.Peer, i uint32) {
 func (p *PiecePicker) HandleCancelDownload(pe *peer.Peer, i uint32) {
 	p.pieces[i].Requested.Remove(pe)
 	p.pieces[i].Snubbed.Remove(pe)
+	p.pieces[i].Choked.Remove(pe)
 }
 
 // HandleDisconnect must be called to remove the peer from internal indexes.

--- a/internal/piecepicker/webseed.go
+++ b/internal/piecepicker/webseed.go
@@ -153,6 +153,9 @@ func (p *PiecePicker) pickLastPieceOfSmallestGap(pe *peer.Peer) *myPiece {
 		// Convert index to int because it goes below zero in loop.
 		for i := int(gap.End - 1); i >= int(gap.Begin); i-- {
 			mp := &p.pieces[i]
+			if mp.Requested.Len() > 0 {
+				continue
+			}
 			if !mp.Having.Has(pe) {
 				continue
 			}

--- a/internal/tracker/httptracker/filter_test.go
+++ b/internal/tracker/httptracker/filter_test.go
@@ -1,0 +1,72 @@
+package httptracker
+
+import (
+	"net"
+	"testing"
+)
+
+func TestFilterExternalIP(t *testing.T) {
+	addr := func(ip string) *net.TCPAddr {
+		return &net.TCPAddr{IP: net.ParseIP(ip).To4(), Port: 6881}
+	}
+	ipBytes := func(ip string) []byte {
+		return []byte(net.ParseIP(ip).To4())
+	}
+	got := func(peers []*net.TCPAddr) []string {
+		out := make([]string, len(peers))
+		for i, p := range peers {
+			out[i] = p.IP.String()
+		}
+		return out
+	}
+	equal := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	cases := []struct {
+		name       string
+		peers      []*net.TCPAddr
+		externalIP []byte
+		want       []string
+	}{
+		{
+			name:       "no external ip is a no-op",
+			peers:      []*net.TCPAddr{addr("1.1.1.1"), addr("2.2.2.2")},
+			externalIP: nil,
+			want:       []string{"1.1.1.1", "2.2.2.2"},
+		},
+		{
+			// self IP at the front: must be removed while every other peer is kept.
+			name:       "removes self at front, keeps the rest",
+			peers:      []*net.TCPAddr{addr("1.1.1.1"), addr("2.2.2.2"), addr("3.3.3.3")},
+			externalIP: ipBytes("1.1.1.1"),
+			want:       []string{"2.2.2.2", "3.3.3.3"},
+		},
+		{
+			name:       "removes self in the middle",
+			peers:      []*net.TCPAddr{addr("2.2.2.2"), addr("1.1.1.1"), addr("3.3.3.3")},
+			externalIP: ipBytes("1.1.1.1"),
+			want:       []string{"2.2.2.2", "3.3.3.3"},
+		},
+		{
+			name:       "external ip not present keeps all",
+			peers:      []*net.TCPAddr{addr("2.2.2.2"), addr("3.3.3.3")},
+			externalIP: ipBytes("9.9.9.9"),
+			want:       []string{"2.2.2.2", "3.3.3.3"},
+		},
+	}
+
+	for _, tc := range cases {
+		if out := got(filterExternalIP(tc.peers, tc.externalIP)); !equal(out, tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, out, tc.want)
+		}
+	}
+}

--- a/internal/tracker/httptracker/httptracker.go
+++ b/internal/tracker/httptracker/httptracker.go
@@ -167,17 +167,8 @@ func (t *HTTPTracker) Announce(ctx context.Context, req tracker.AnnounceRequest)
 	}
 	t.log.Debugf("got %d peers", len(peers))
 
-	// Filter external IP
-	if len(response.ExternalIP) != 0 {
-		var filtered int
-		for i, p := range peers {
-			if !bytes.Equal(p.IP[:], response.ExternalIP) {
-				peers[i] = p
-				filtered++
-			}
-		}
-		peers = peers[:filtered]
-	}
+	// Remove our own address from the peer list.
+	peers = filterExternalIP(peers, response.ExternalIP)
 
 	return &tracker.AnnounceResponse{
 		Interval:       time.Duration(response.Interval) * time.Second,
@@ -187,6 +178,22 @@ func (t *HTTPTracker) Announce(ctx context.Context, req tracker.AnnounceRequest)
 		Peers:          peers,
 		WarningMessage: response.WarningMessage,
 	}, nil
+}
+
+// filterExternalIP returns peers with any entry matching the client's own
+// external IP (as reported by the tracker) removed, so the client does not try
+// to connect to itself. It filters in place, preserving order.
+func filterExternalIP(peers []*net.TCPAddr, externalIP []byte) []*net.TCPAddr {
+	if len(externalIP) == 0 {
+		return peers
+	}
+	kept := peers[:0]
+	for _, p := range peers {
+		if !bytes.Equal(p.IP[:], externalIP) {
+			kept = append(kept, p)
+		}
+	}
+	return kept
 }
 
 // percentEscape puts `%` before every byte.

--- a/internal/tracker/udptracker/backoff.go
+++ b/internal/tracker/udptracker/backoff.go
@@ -9,7 +9,7 @@ func (b *udpBackOff) NextBackOff() time.Duration {
 	if *b > 8 {
 		*b = 8
 	}
-	return time.Duration(15*(2^*b)) * time.Second
+	return time.Duration(15*(1<<*b)) * time.Second
 }
 
 func (b *udpBackOff) Reset() { *b = 0 }

--- a/internal/tracker/udptracker/backoff_test.go
+++ b/internal/tracker/udptracker/backoff_test.go
@@ -1,0 +1,30 @@
+package udptracker
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUDPBackOff verifies the BEP-15 retransmission schedule: the timeout is
+// 15 * 2^n seconds, with n increasing from 0 and capped at 8 (3840s).
+func TestUDPBackOff(t *testing.T) {
+	want := []time.Duration{
+		15 * time.Second,
+		30 * time.Second,
+		60 * time.Second,
+		120 * time.Second,
+		240 * time.Second,
+		480 * time.Second,
+		960 * time.Second,
+		1920 * time.Second,
+		3840 * time.Second,
+		3840 * time.Second, // n capped at 8
+		3840 * time.Second,
+	}
+	var b udpBackOff
+	for i, w := range want {
+		if got := b.NextBackOff(); got != w {
+			t.Errorf("call %d: got %s, want %s", i, got, w)
+		}
+	}
+}

--- a/internal/urldownloader/job.go
+++ b/internal/urldownloader/job.go
@@ -8,6 +8,10 @@ type downloadJob struct {
 	Filename   string
 	RangeBegin int64
 	Length     int64
+	// Padding jobs are not requested from the server because padding files
+	// do not exist there. Their bytes are always zero and are skipped over
+	// in the piece buffer instead.
+	Padding bool
 }
 
 func createJobs(pieces []piece.Piece, begin, end uint32) []downloadJob {
@@ -24,10 +28,11 @@ func createJobs(pieces []piece.Piece, begin, end uint32) []downloadJob {
 					Filename:   sec.Name,
 					RangeBegin: sec.Offset,
 					Length:     sec.Length,
+					Padding:    sec.Padding,
 				}
 				continue
 			}
-			if sec.Name == job.Filename {
+			if sec.Name == job.Filename && sec.Padding == job.Padding {
 				job.Length += sec.Length
 				continue
 			}
@@ -38,6 +43,7 @@ func createJobs(pieces []piece.Piece, begin, end uint32) []downloadJob {
 				Filename:   sec.Name,
 				RangeBegin: sec.Offset,
 				Length:     sec.Length,
+				Padding:    sec.Padding,
 			}
 		}
 	}

--- a/internal/urldownloader/job_test.go
+++ b/internal/urldownloader/job_test.go
@@ -113,3 +113,44 @@ func TestCreateJobs(t *testing.T) {
 	}, createJobs(pieces, 2, 3))
 	assert.Equal(t, ([]downloadJob)(nil), createJobs(pieces, 2, 2))
 }
+
+func TestCreateJobsPadding(t *testing.T) {
+	// Piece length is 16. fileA and fileB are aligned to piece boundaries
+	// with padding files (BEP 47). fileB spans pieces 1 and 2.
+	pieces := []piece.Piece{
+		{
+			Data: []filesection.FileSection{
+				{Name: "fileA", Offset: 0, Length: 10},
+				{Name: ".pad/6", Offset: 0, Length: 6, Padding: true},
+			},
+		},
+		{
+			Data: []filesection.FileSection{
+				{Name: "fileB", Offset: 0, Length: 16},
+			},
+		},
+		{
+			Data: []filesection.FileSection{
+				{Name: "fileB", Offset: 16, Length: 4},
+				{Name: ".pad/12", Offset: 0, Length: 12, Padding: true},
+			},
+		},
+		{
+			Data: []filesection.FileSection{
+				{Name: "fileC", Offset: 0, Length: 4},
+			},
+		},
+	}
+	assert.Equal(t, []downloadJob{
+		{Filename: "fileA", RangeBegin: 0, Length: 10},
+		{Filename: ".pad/6", RangeBegin: 0, Length: 6, Padding: true},
+		{Filename: "fileB", RangeBegin: 0, Length: 20},
+		{Filename: ".pad/12", RangeBegin: 0, Length: 12, Padding: true},
+		{Filename: "fileC", RangeBegin: 0, Length: 4},
+	}, createJobs(pieces, 0, 4))
+	assert.Equal(t, []downloadJob{
+		{Filename: "fileB", RangeBegin: 16, Length: 4},
+		{Filename: ".pad/12", RangeBegin: 0, Length: 12, Padding: true},
+		{Filename: "fileC", RangeBegin: 0, Length: 4},
+	}, createJobs(pieces, 2, 4))
+}

--- a/internal/urldownloader/urldownloader.go
+++ b/internal/urldownloader/urldownloader.go
@@ -90,6 +90,40 @@ func (d *URLDownloader) Run(client *http.Client, pieces []piece.Piece, multifile
 	var n int // position in piece
 	buf := pool.Get(int(pieces[d.current].Length))
 
+	// completePiece sends the filled piece buffer as a result and prepares
+	// the buffer for the next piece. Returns true if this was the last piece.
+	completePiece := func() (done bool) {
+		index := d.current
+		done = d.current >= d.readEnd()-1
+		d.sendResult(resultC, &PieceResult{Downloader: d, Buffer: buf, Index: index, Done: done})
+		if done {
+			return true
+		}
+		d.incrCurrent()
+		// Allocate new buffer for next piece
+		n = 0
+		buf = pool.Get(int(pieces[d.current].Length))
+		return false
+	}
+
+	// processPadding advances the position in the piece buffer without making
+	// a request. Padding files do not exist on the server. Their bytes are
+	// always zero and the buffer comes zeroed from the pool.
+	processPadding := func(job downloadJob) bool {
+		var m int64 // position in padding
+		for m < job.Length {
+			skipSize := calcReadSize(buf, n, job, m)
+			n += int(skipSize)
+			m += skipSize
+			if n == len(buf.Data) { // piece completed
+				if completePiece() {
+					return true
+				}
+			}
+		}
+		return true
+	}
+
 	processJob := func(job downloadJob) bool {
 		u := d.getURL(job.Filename, multifile)
 		req, err := http.NewRequest(http.MethodGet, u, nil)
@@ -131,22 +165,20 @@ func (d *URLDownloader) Run(client *http.Client, pieces []piece.Piece, multifile
 			n += o
 			m += int64(o)
 			if n == len(buf.Data) { // piece completed
-				index := d.current
-				done := d.current >= d.readEnd()-1
-				d.sendResult(resultC, &PieceResult{Downloader: d, Buffer: buf, Index: index, Done: done})
-				if done {
+				if completePiece() {
 					return true
 				}
-				d.incrCurrent()
-				// Allocate new buffer for next piece
-				n = 0
-				buf = pool.Get(int(pieces[d.current].Length))
 			}
 		}
 		return true
 	}
 	for _, job := range jobs {
-		ok := processJob(job)
+		var ok bool
+		if job.Padding {
+			ok = processPadding(job)
+		} else {
+			ok = processJob(job)
+		}
 		if !ok {
 			buf.Release()
 			break

--- a/internal/urldownloader/urldownloader.go
+++ b/internal/urldownloader/urldownloader.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -213,14 +215,27 @@ func (d *URLDownloader) getURL(filename string, multifile bool) string {
 	src := d.URL
 	if !multifile {
 		if src[len(src)-1] == '/' {
-			src += url.PathEscape(filename)
+			src += escapeFilePath(filename)
 		}
 		return src
 	}
 	if src[len(src)-1] != '/' {
 		src += "/"
 	}
-	return src + url.PathEscape(filename)
+	return src + escapeFilePath(filename)
+}
+
+// escapeFilePath escapes each segment of the file's relative path separately,
+// keeping separators as literal slashes in the URL as required by BEP 19.
+// Escaping the whole path with url.PathEscape would encode separators as %2F,
+// which is not equivalent to a slash (RFC 3986) and is rejected by some servers.
+// Paths are built with filepath.Join, so they are split on the OS path separator.
+func escapeFilePath(filename string) string {
+	parts := strings.Split(filename, string(filepath.Separator))
+	for i := range parts {
+		parts[i] = url.PathEscape(parts[i])
+	}
+	return strings.Join(parts, "/")
 }
 
 func (d *URLDownloader) sendResult(resultC chan *PieceResult, res *PieceResult) {

--- a/internal/urldownloader/urldownloader_test.go
+++ b/internal/urldownloader/urldownloader_test.go
@@ -1,0 +1,130 @@
+package urldownloader
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/rain/v2/internal/bufferpool"
+	"github.com/cenkalti/rain/v2/internal/filesection"
+	"github.com/cenkalti/rain/v2/internal/piece"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPadding(t *testing.T) {
+	// Files have position-varying contents so that wrong offsets in piece
+	// buffers are detected.
+	newFile := func(base byte, length int) []byte {
+		b := make([]byte, length)
+		for i := range b {
+			b[i] = base + byte(i)
+		}
+		return b
+	}
+	fileA := newFile(0x10, 10)
+	fileB := newFile(0x30, 20)
+	fileC := newFile(0x60, 4)
+	files := map[string][]byte{"fileA": fileA, "fileB": fileB, "fileC": fileC}
+
+	// Padding files are not present on the server, like real webseed servers.
+	var mu sync.Mutex
+	var requestedPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		mu.Unlock()
+		data, ok := files[r.URL.Path[1:]]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		http.ServeContent(w, r, r.URL.Path[1:], time.Time{}, bytes.NewReader(data))
+	}))
+	defer srv.Close()
+
+	// Piece length is 16. fileA and fileB are aligned to piece boundaries
+	// with padding files (BEP 47). fileB spans pieces 1 and 2.
+	pieces := []piece.Piece{
+		{Index: 0, Length: 16, Data: []filesection.FileSection{
+			{Name: "fileA", Offset: 0, Length: 10},
+			{Name: ".pad/6", Offset: 0, Length: 6, Padding: true},
+		}},
+		{Index: 1, Length: 16, Data: []filesection.FileSection{
+			{Name: "fileB", Offset: 0, Length: 16},
+		}},
+		{Index: 2, Length: 16, Data: []filesection.FileSection{
+			{Name: "fileB", Offset: 16, Length: 4},
+			{Name: ".pad/12", Offset: 0, Length: 12, Padding: true},
+		}},
+		{Index: 3, Length: 4, Data: []filesection.FileSection{
+			{Name: "fileC", Offset: 0, Length: 4},
+		}},
+	}
+	concat := func(parts ...[]byte) []byte {
+		var b []byte
+		for _, p := range parts {
+			b = append(b, p...)
+		}
+		return b
+	}
+	expected := [][]byte{
+		concat(fileA, make([]byte, 6)),
+		fileB[:16],
+		concat(fileB[16:], make([]byte, 12)),
+		fileC,
+	}
+
+	run := func(begin, end uint32) []*PieceResult {
+		d := New(srv.URL, begin, end, nil)
+		pool := bufferpool.New(16)
+		resultC := make(chan *PieceResult)
+		go d.Run(http.DefaultClient, pieces, true, resultC, pool, 5*time.Second)
+		var results []*PieceResult
+		for {
+			select {
+			case res := <-resultC:
+				require.NoError(t, res.Error)
+				results = append(results, res)
+				if res.Done {
+					d.Close()
+					return results
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for piece result")
+			}
+		}
+	}
+
+	// Download all pieces.
+	results := run(0, 4)
+	require.Len(t, results, 4)
+	for i, res := range results {
+		assert.Equal(t, uint32(i), res.Index)
+		assert.Equal(t, expected[i], res.Buffer.Data, "piece #%d", i)
+		assert.Equal(t, i == 3, res.Done)
+		res.Buffer.Release()
+	}
+
+	// Download a sub-range beginning at a piece that starts mid-file.
+	results = run(2, 4)
+	require.Len(t, results, 2)
+	for i, res := range results {
+		index := 2 + i
+		assert.Equal(t, uint32(index), res.Index)
+		assert.Equal(t, expected[index], res.Buffer.Data, "piece #%d", index)
+		assert.Equal(t, index == 3, res.Done)
+		res.Buffer.Release()
+	}
+
+	// Padding files must never be requested from the server.
+	mu.Lock()
+	defer mu.Unlock()
+	assert.NotEmpty(t, requestedPaths)
+	for _, p := range requestedPaths {
+		assert.NotContains(t, p, "pad")
+	}
+}

--- a/internal/urldownloader/urldownloader_test.go
+++ b/internal/urldownloader/urldownloader_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -28,21 +30,30 @@ func TestRunPadding(t *testing.T) {
 	fileA := newFile(0x10, 10)
 	fileB := newFile(0x30, 20)
 	fileC := newFile(0x60, 4)
-	files := map[string][]byte{"fileA": fileA, "fileB": fileB, "fileC": fileC}
+	// Names are relative paths with subdirectories, built with filepath.Join
+	// like metainfo does. One segment contains a space to verify that
+	// segments are still escaped individually.
+	fileAName := filepath.Join("d", "fileA")
+	fileBName := filepath.Join("d", "fileB")
+	fileCName := filepath.Join("d", "sub", "file c")
+	files := map[string][]byte{fileAName: fileA, fileBName: fileB, fileCName: fileC}
 
 	// Padding files are not present on the server, like real webseed servers.
 	var mu sync.Mutex
-	var requestedPaths []string
+	var requestURIs []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
-		requestedPaths = append(requestedPaths, r.URL.Path)
+		// RequestURI is the raw URI from the request line. URL.Path cannot be
+		// used here because the server decodes %2F back to a slash in it.
+		requestURIs = append(requestURIs, r.RequestURI)
 		mu.Unlock()
-		data, ok := files[r.URL.Path[1:]]
+		name := filepath.FromSlash(strings.TrimPrefix(r.URL.Path, "/"))
+		data, ok := files[name]
 		if !ok {
 			http.NotFound(w, r)
 			return
 		}
-		http.ServeContent(w, r, r.URL.Path[1:], time.Time{}, bytes.NewReader(data))
+		http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(data))
 	}))
 	defer srv.Close()
 
@@ -50,18 +61,18 @@ func TestRunPadding(t *testing.T) {
 	// with padding files (BEP 47). fileB spans pieces 1 and 2.
 	pieces := []piece.Piece{
 		{Index: 0, Length: 16, Data: []filesection.FileSection{
-			{Name: "fileA", Offset: 0, Length: 10},
+			{Name: fileAName, Offset: 0, Length: 10},
 			{Name: ".pad/6", Offset: 0, Length: 6, Padding: true},
 		}},
 		{Index: 1, Length: 16, Data: []filesection.FileSection{
-			{Name: "fileB", Offset: 0, Length: 16},
+			{Name: fileBName, Offset: 0, Length: 16},
 		}},
 		{Index: 2, Length: 16, Data: []filesection.FileSection{
-			{Name: "fileB", Offset: 16, Length: 4},
+			{Name: fileBName, Offset: 16, Length: 4},
 			{Name: ".pad/12", Offset: 0, Length: 12, Padding: true},
 		}},
 		{Index: 3, Length: 4, Data: []filesection.FileSection{
-			{Name: "fileC", Offset: 0, Length: 4},
+			{Name: fileCName, Offset: 0, Length: 4},
 		}},
 	}
 	concat := func(parts ...[]byte) []byte {
@@ -120,11 +131,13 @@ func TestRunPadding(t *testing.T) {
 		res.Buffer.Release()
 	}
 
-	// Padding files must never be requested from the server.
+	// Each file is requested once per run with its exact raw URI: path
+	// separators as literal slashes (not %2F, see BEP 19), other special
+	// characters escaped per segment, and no requests for padding files.
 	mu.Lock()
 	defer mu.Unlock()
-	assert.NotEmpty(t, requestedPaths)
-	for _, p := range requestedPaths {
-		assert.NotContains(t, p, "pad")
-	}
+	assert.Equal(t, []string{
+		"/d/fileA", "/d/fileB", "/d/sub/file%20c", // run(0, 4)
+		"/d/fileB", "/d/sub/file%20c", // run(2, 4)
+	}, requestURIs)
 }

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -419,9 +419,11 @@ func (s *Session) StartAll() error {
 	if err != nil {
 		return err
 	}
+	s.mTorrents.RLock()
 	for _, t := range s.torrents {
 		t.torrent.Start()
 	}
+	s.mTorrents.RUnlock()
 	return nil
 }
 
@@ -440,8 +442,10 @@ func (s *Session) StopAll() error {
 	if err != nil {
 		return err
 	}
+	s.mTorrents.RLock()
 	for _, t := range s.torrents {
 		t.torrent.Stop()
 	}
+	s.mTorrents.RUnlock()
 	return nil
 }

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -367,6 +367,9 @@ func (s *Session) removeTorrentFromClient(id string) (*Torrent, error) {
 			break
 		}
 	}
+	// Read the map while still holding the lock; it must not be accessed after
+	// Unlock since concurrent Add/Remove operations mutate it.
+	lastWithInfoHash := len(s.torrentsByInfoHash[ih]) == 0
 
 	// DHT.RemoveInfoHash below sends a message to DHT loop, hence it is blocking.
 	// We need to make sure that we are not holding any lock that cause a block in DHT loop.
@@ -374,7 +377,7 @@ func (s *Session) removeTorrentFromClient(id string) (*Torrent, error) {
 	// DHT.PeersRequestResults. That's why we are releasing the lock before calling DHT.RemoveInfoHash.
 	s.mTorrents.Unlock()
 
-	if s.config.DHTEnabled && len(s.torrentsByInfoHash[ih]) == 0 {
+	if s.config.DHTEnabled && lastWithInfoHash {
 		s.dht.RemoveInfoHash(string(ih))
 	}
 	return t, s.db.Update(func(tx *bbolt.Tx) error {

--- a/torrent/session.go
+++ b/torrent/session.go
@@ -422,11 +422,18 @@ func (s *Session) StartAll() error {
 	if err != nil {
 		return err
 	}
+	// Snapshot the torrents under the lock, then start them without holding it.
+	// Start() blocks on an unbuffered channel until the torrent loop receives,
+	// so calling it under the lock could stall concurrent Add/Remove.
 	s.mTorrents.RLock()
+	torrents := make([]*Torrent, 0, len(s.torrents))
 	for _, t := range s.torrents {
-		t.torrent.Start()
+		torrents = append(torrents, t)
 	}
 	s.mTorrents.RUnlock()
+	for _, t := range torrents {
+		t.torrent.Start()
+	}
 	return nil
 }
 
@@ -445,10 +452,17 @@ func (s *Session) StopAll() error {
 	if err != nil {
 		return err
 	}
+	// Snapshot the torrents under the lock, then stop them without holding it.
+	// Stop() blocks on an unbuffered channel until the torrent loop receives,
+	// so calling it under the lock could stall concurrent Add/Remove.
 	s.mTorrents.RLock()
+	torrents := make([]*Torrent, 0, len(s.torrents))
 	for _, t := range s.torrents {
-		t.torrent.Stop()
+		torrents = append(torrents, t)
 	}
 	s.mTorrents.RUnlock()
+	for _, t := range torrents {
+		t.torrent.Stop()
+	}
 	return nil
 }

--- a/torrent/torrent_messagehandler.go
+++ b/torrent/torrent_messagehandler.go
@@ -239,8 +239,8 @@ func (t *torrent) handlePeerMessage(pm peer.Message) {
 			t.closePeer(pe)
 			break
 		}
-		if msg.Begin+msg.Length > t.pieces[msg.Index].Length {
-			pe.Logger().Errorln("invalid request length:", msg.Length)
+		if !validPieceRequest(msg.Begin, msg.Length, t.pieces[msg.Index].Length) {
+			pe.Logger().Errorln("invalid request begin:", msg.Begin, "length:", msg.Length)
 			t.closePeer(pe)
 			break
 		}
@@ -357,6 +357,14 @@ func (t *torrent) handlePeerMessage(pm peer.Message) {
 	default:
 		t.crash(fmt.Sprintf("unhandled peer message type: %T", msg))
 	}
+}
+
+// validPieceRequest reports whether a peer's "request" message for a block of
+// the given piece length is in bounds. begin and length are attacker-controlled
+// uint32 values, so the sum is computed in uint64 to avoid an overflow that
+// would let a request with a large begin slip past the bounds check.
+func validPieceRequest(begin, length, pieceLength uint32) bool {
+	return length != 0 && uint64(begin)+uint64(length) <= uint64(pieceLength)
 }
 
 func (t *torrent) updateInterestedState(pe *peer.Peer) {

--- a/torrent/torrent_messagehandler_test.go
+++ b/torrent/torrent_messagehandler_test.go
@@ -1,0 +1,34 @@
+package torrent
+
+import "testing"
+
+func TestValidPieceRequest(t *testing.T) {
+	const pieceLength = 256 * 1024 // 262144
+
+	cases := []struct {
+		name        string
+		begin       uint32
+		length      uint32
+		pieceLength uint32
+		want        bool
+	}{
+		{"normal block at start", 0, 16384, pieceLength, true},
+		{"normal block mid piece", 16384, 16384, pieceLength, true},
+		{"exact end of piece", pieceLength - 16384, 16384, pieceLength, true},
+		{"whole piece", 0, pieceLength, pieceLength, true},
+		{"zero length", 0, 0, pieceLength, false},
+		{"runs one byte past end", pieceLength - 16384, 16385, pieceLength, false},
+		{"begin past end", pieceLength, 1, pieceLength, false},
+		// begin+length overflows uint32 and wraps to a small value; the old
+		// check (begin+length > pieceLength in uint32) would let this through.
+		{"overflowing begin", 0xFFFFFFFF, 16384, pieceLength, false},
+		{"overflowing begin small wrap", 0xFFFFF000, 0x4000, pieceLength, false},
+	}
+
+	for _, tc := range cases {
+		if got := validPieceRequest(tc.begin, tc.length, tc.pieceLength); got != tc.want {
+			t.Errorf("%s: validPieceRequest(%#x, %#x, %d) = %v, want %v",
+				tc.name, tc.begin, tc.length, tc.pieceLength, got, tc.want)
+		}
+	}
+}

--- a/torrent/torrent_metadataextension.go
+++ b/torrent/torrent_metadataextension.go
@@ -66,6 +66,8 @@ func (t *torrent) handleMetadataMessage(pe *peer.Peer, msg peerprotocol.Extensio
 			break
 		}
 		if !id.Done() {
+			pe.Snubbed = false
+			delete(t.infoDownloadersSnubbed, pe)
 			id.RequestBlocks(t.maxAllowedRequests(pe))
 			pe.ResetSnubTimer()
 			break

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -135,6 +135,7 @@ func (t *torrent) startPeer(
 	if ok {
 		t.log.Debugf("peer with same id already connected. addr: %s id: %s", addr, peerID)
 		conn.Close()
+		delete(t.connectedPeerIPs, addr.IP.String())
 		t.pexDropPeer(addr)
 		t.dialAddresses()
 		return

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -49,6 +49,7 @@ func (t *torrent) addPeerString(addr string) error {
 func (t *torrent) resolveAndAddPeer(host string, port int) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
+	defer close(done)
 	go func() {
 		select {
 		case <-t.closeC:

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -142,7 +142,7 @@ func (t *torrent) startPeer(
 	}
 	t.peerIDs[peerID] = struct{}{}
 
-	pe := peer.New(conn, source, peerID, extensions, cipher, t.session.config.PieceReadTimeout, t.session.config.RequestTimeout, t.session.config.MaxRequestsIn, t.session.bucketDownload, t.session.bucketUpload)
+	pe := peer.New(conn, source, peerID, extensions, cipher, t.session.config.PieceReadTimeout, t.session.config.RequestTimeout, t.session.config.MaxRequestsIn, int(t.session.config.MaxMetadataSize), t.session.bucketDownload, t.session.bucketUpload)
 	t.peers[pe] = struct{}{}
 	peers[pe] = struct{}{}
 	if t.info != nil {

--- a/torrent/torrent_pieces.go
+++ b/torrent/torrent_pieces.go
@@ -27,9 +27,7 @@ func (t *torrent) checkCompletion() bool {
 		h.Close()
 	}
 	t.outgoingHandshakers = make(map[*outgoinghandshaker.OutgoingHandshaker]struct{})
-	for _, src := range t.webseedSources {
-		t.closeWebseedDownloader(src)
-	}
+	t.stopWebseedDownloads()
 	for pe := range t.peers {
 		if !pe.PeerInterested {
 			t.closePeer(pe)

--- a/torrent/torrent_stop.go
+++ b/torrent/torrent_stop.go
@@ -117,6 +117,11 @@ func (t *torrent) stopWebseedDownloads() {
 	for _, src := range t.webseedSources {
 		t.closeWebseedDownloader(src)
 	}
+	// All webseed downloaders are now closed. Closing them does not go through
+	// handleWebseedPieceResult, so the active-downloads counter is not
+	// decremented per source; reset it here to avoid leaking slots across
+	// stop/restart cycles.
+	t.webseedActiveDownloads = 0
 }
 
 func (t *torrent) resetSpeeds() {

--- a/torrent/torrent_webseed.go
+++ b/torrent/torrent_webseed.go
@@ -22,6 +22,36 @@ func (t *torrent) handleWebseedPieceResult(msg *urldownloader.PieceResult) {
 	}
 
 	piece := &t.pieces[msg.Index]
+
+	// The piece may have already been completed by a peer that was downloading
+	// it concurrently: webseed ranges and peer downloads can overlap, and when
+	// a peer finishes such a piece the webseed range is only truncated after
+	// the fact (see WebseedStopAt). A result that was already in flight then
+	// arrives for a piece that is now Done. Writing it again would trip the
+	// "already have the piece" check in handlePieceWriteDone, so discard the
+	// stale result. This mirrors handlePieceMessage, which drops blocks whose
+	// downloader is no longer current.
+	if piece.Done {
+		t.log.Debugf("discarding already completed piece #%d from webseed %s", msg.Index, msg.Downloader.URL)
+		t.bytesWasted.Inc(int64(len(msg.Buffer.Data)))
+		msg.Buffer.Release()
+		if msg.Done {
+			for _, src := range t.webseedSources {
+				// Match by downloader identity: the source may already have a
+				// different (or no) downloader if it was closed elsewhere, in
+				// which case there is nothing to clean up here.
+				if src.Downloader != msg.Downloader {
+					continue
+				}
+				t.closeWebseedDownloader(src)
+				t.webseedActiveDownloads--
+				t.startPieceDownloaderForWebseed(src)
+				break
+			}
+		}
+		return
+	}
+
 	t.log.Debugf("piece #%d downloaded from %s", msg.Index, msg.Downloader.URL)
 
 	t.bytesDownloaded.Inc(int64(len(msg.Buffer.Data)))

--- a/torrent/torrent_write.go
+++ b/torrent/torrent_write.go
@@ -28,6 +28,8 @@ func (t *torrent) handlePieceWriteDone(pw *piecewriter.PieceWriter) {
 		case *urldownloader.URLDownloader:
 			t.log.Debugln("received corrupt piece from webseed", src.URL)
 			t.disableSource(src.URL, errors.New("corrupt piece"), false)
+			// disableSource closed the webseed downloader, so free its slot.
+			t.webseedActiveDownloads--
 		default:
 			t.crash("unhandled piece source")
 		}
@@ -54,6 +56,9 @@ func (t *torrent) handlePieceWriteDone(pw *piecewriter.PieceWriter) {
 			closed := t.piecePicker.WebseedStopAt(src, pw.Piece.Index)
 			if closed {
 				t.log.Debugf("closed webseed downloader: %s", src.URL)
+				// WebseedStopAt closed the downloader, so free its slot before
+				// trying to start a new range (which re-takes a slot on success).
+				t.webseedActiveDownloads--
 				t.startPieceDownloaderForWebseed(src)
 			}
 		}


### PR DESCRIPTION
Bug fixes from a correctness, concurrency, and security audit of the client. Each commit is a focused, independent fix with the rationale in its message; grouped below by area. Verified with `go build ./...`, `go test -race ./...`, and `golangci-lint run`.

## BEP-47 padding & webseed lifecycle
- **fix filesection.Write not skipping padding bytes in buffer** — padding regions were written to disk instead of skipped, corrupting file alignment.
- **fix webseed requesting padding files from server** — webseed GETs for nonexistent `.pad/<len>` files returned 404 and disabled the source; padding is now satisfied from the (zeroed) buffer.
- **fix webseed URLs escaping path separators as %2F** — multi-file webseed paths were escaped as a single segment, turning `/` into `%2F` (rejected by e.g. Apache); now escaped per segment.
- **accept BEP 47 torrents with duplicate pad file paths** — the duplicate-path check rejected valid torrents whose pad files share the conventional `.pad/<len>` path; padding files are now exempt.
- **fix duplicate piece assignment to peers during webseed download** — all unchoked peers could be handed the same piece while a webseed was active, causing unbounded duplicate downloads.
- **discard webseed piece result for already completed piece** — a webseed result racing with completion of the same piece by a peer triggered a redundant write and the `already have the piece` crash.
- **fix webseedActiveDownloads counter leak on webseed downloader close** — closing a downloader via `WebseedStopAt`/corrupt-piece paths didn't decrement the active counter.
- **reset webseedActiveDownloads when tearing down webseed downloads** — stop/completion teardown leaked the counter, progressively killing webseed capacity across pause/resume cycles.

## Concurrency / data races
- **fix data race on torrentsByInfoHash in removeTorrentFromClient** — the map was read after `Unlock()`, racing with concurrent add/remove (`fatal error: concurrent map read and map write`).
- **fix data race in StartAll/StopAll**

## Security / DoS hardening (untrusted peer/tracker input)
- **reject oversized peer messages before allocating** — bitfield/extension messages sized a buffer directly from an attacker-controlled length, allowing a single peer to force a ~4 GB allocation; now capped at the metadata-size limit.
- **fix negative metadata_size bypassing validation (remote DoS)**
- **harden piece request bounds check against uint32 overflow**

## Resource leaks
- **fix goroutine and context leak in resolveAndAddPeer**
- **fix connectedPeerIPs leak on duplicate peer id**
- **fix piece picker leaking choked peers on cancel/disconnect**

## Trackers & peer discovery
- **fix UDP tracker backoff using XOR instead of exponentiation**
- **fix HTTP tracker external-IP filter dropping wrong peers**
- **fix per-source peer count on eviction in addrlist**

## Metadata download
- **clear snubbed state when info downloader receives data** — a recovered-but-still-snubbed peer kept counting against the active total, letting `startInfoDownloaders` exceed `ParallelMetadataDownloads`.
